### PR TITLE
Add depends to p4rt debian package

### DIFF
--- a/p4rt_app/BUILD.bazel
+++ b/p4rt_app/BUILD.bazel
@@ -68,6 +68,17 @@ pkg_tar(
     visibility = ["//visibility:private"],
 )
 
+# Here's how to generate the list of Debian packages that contain the shared
+# libraries that the p4rt binary depends on. It's probably better to manually
+# manage the "depends" list in p4rt_deb, but this can help in debugging when
+# a dependency (or transitive dependency) changes.
+#
+#   ldd bazel-out/k8-fastbuild/bin/p4rt_app/p4rt | \
+#     sed "s/^[[:space:]]*\([^ ]*\.so[^ ]*\).*$/\1/" | \
+#     xargs -n1 -I{} bash -c "dpkg -S {} 2>/dev/null || true" | \
+#     cut -d: -f1 | \
+#     sort -u
+#
 pkg_deb(
     name = "p4rt_deb",
     architecture = "amd64",
@@ -82,6 +93,10 @@ pkg_deb(
     name = "p4rt_dbg_deb",
     architecture = "amd64",
     data = ":p4rt_debug",
+    depends = [
+        "libswsscommon",
+        "libgmpxx4ldbl",
+    ],
     description = "P4RT service debug symbols",
     maintainer = p4rt_maintainer,
     package = "sonic-p4rt-dbgsym",


### PR DESCRIPTION
libswsscommon is actually linked statically, so not
technically a dependency, but it is installed anyway
by the build system so there's no harm either.

libswsscommon pulls in transitive libraries we do need:
  libhiredis, libnl*, libc, libgcc, libstdc++

libgmpxx4ldbl required for p4_symbolic