### PR TITLE
[Thinkit/Tests] Adding standalone tests for PTP behaviors.

### DIFF
--- a/tests/forwarding/BUILD.bazel
+++ b/tests/forwarding/BUILD.bazel
@@ -550,6 +550,40 @@ cc_library(
 )
 
 cc_library(
+    name = "timestamping_test",
+    testonly = True,
+    srcs = ["timestamping_test.cc"],
+    hdrs = ["timestamping_test.h"],
+    linkstatic = 1,
+    deps = [
+        ":util",
+        "//gutil:status_matchers",
+        "//lib/gnmi:gnmi_helper",
+        "//p4_pdpi:ir",
+        "//p4_pdpi:ir_cc_proto",
+        "//p4_pdpi:p4_runtime_session",
+        "//p4_pdpi/packetlib",
+        "//p4_pdpi/packetlib:packetlib_cc_proto",
+        "//tests/lib:common_ir_table_entries",
+        "//tests/lib:p4rt_fixed_table_programming_helper",
+        "//tests/lib:switch_test_setup_helpers",
+        "//thinkit:mirror_testbed_fixture",
+        "@com_github_gnmi//proto/gnmi:gnmi_cc_grpc_proto",
+        "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/strings:string_view",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+    alwayslink = True,
+)
+
+cc_library(
     name = "mirror_blackbox_test_fixture",
     testonly = True,
     srcs = ["mirror_blackbox_test_fixture.cc"],

--- a/tests/forwarding/timestamping_test.cc
+++ b/tests/forwarding/timestamping_test.cc
@@ -1,0 +1,556 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "tests/forwarding/timestamping_test.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/substitute.h"
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "gutil/status.h"
+#include "gutil/status_matchers.h"
+#include "lib/gnmi/gnmi_helper.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "p4_pdpi/packetlib/packetlib.h"
+#include "p4_pdpi/packetlib/packetlib.pb.h"
+#include "tests/forwarding/util.h"
+#include "tests/lib/common_ir_table_entries.h"
+#include "tests/lib/p4rt_fixed_table_programming_helper.h"
+
+namespace pins {
+namespace {
+
+// PTP headers exist inside a UDP header so the specific MAC addresses do not
+// matter for testing. We use this global MAC to ensure the flows we install on
+// the switch and packets we send to the switch are in sync.
+const absl::string_view kSwitchMac = "00:11:11:11:11:11";
+
+// When parsing packet headers a PTP header is identified by a UDP packet with
+// destination port 319 (0x013f in hex).
+const absl::string_view kPtpEventUdpDstPort = "0x013f";
+
+// send_to_ingress is a special port created on the switch which allows the CPU
+// to inject a packet into the ingress pipeline.
+constexpr absl::string_view kSendToIngress = "send_to_ingress";
+
+absl::Status PuntAllPacketToCpu(pdpi::P4RuntimeSession& session,
+                                const pdpi::IrP4Info& ir_p4info) {
+  LOG(INFO) << "Punting all packet to the CPU.";
+  p4::v1::WriteRequest write_request;
+
+  auto& update = *write_request.add_updates();
+  update.set_type(p4::v1::Update::INSERT);
+  ASSIGN_OR_RETURN(
+      *update.mutable_entity()->mutable_table_entry(),
+      pdpi::IrTableEntryToPi(ir_p4info, PuntAllPacketsToControllerIrTableEntry(
+                                            /*queue_id=*/"0x7")));
+
+  return pdpi::SetMetadataAndSendPiWriteRequest(&session, write_request);
+}
+
+absl::Status SendAllTrafficToVrf(pdpi::P4RuntimeSession& session,
+                                 const pdpi::IrP4Info& ir_p4info,
+                                 absl::string_view vrf_id) {
+  LOG(INFO) << absl::StreamFormat(
+      "Creating VRF '%s' and assigning all traffic to it.", vrf_id);
+  p4::v1::WriteRequest write_request;
+  ASSIGN_OR_RETURN(*write_request.add_updates(),
+                   VrfTableUpdate(ir_p4info, p4::v1::Update::INSERT, vrf_id));
+
+  auto& forward_vrf_update = *write_request.add_updates();
+  forward_vrf_update.set_type(p4::v1::Update::INSERT);
+  ASSIGN_OR_RETURN(*forward_vrf_update.mutable_entity()->mutable_table_entry(),
+                   pdpi::IrTableEntryToPi(
+                       ir_p4info, SetVrfIdForAllPacketsIrTableEntry(vrf_id)));
+
+  return pdpi::SetMetadataAndSendPiWriteRequest(&session, write_request);
+}
+
+absl::StatusOr<std::vector<WcmpAction>> CreateNextHopsForPorts(
+    pdpi::P4RuntimeSession& session, const pdpi::IrP4Info& ir_p4info,
+    absl::Span<const std::string> ports) {
+  const absl::string_view kPeerSwitchMac = "00:22:22:22:22:22";
+  const absl::string_view kNeighborId = "fe80::2";
+
+  p4::v1::WriteRequest write_request;
+  std::vector<WcmpAction> nexthop_info;
+  for (const std::string& port : ports) {
+    std::string rif_id = absl::StrCat("rif-", port);
+    std::string nexthop_id = absl::StrCat("nexthop-", port);
+
+    LOG(INFO) << absl::StreamFormat(
+        "Adding nexthop route from (%s) to (%s,%s) through: %s, and %s",
+        kSwitchMac, kPeerSwitchMac, kNeighborId, rif_id, nexthop_id);
+
+    ASSIGN_OR_RETURN(
+        *write_request.add_updates(),
+        RouterInterfaceTableUpdate(ir_p4info, p4::v1::Update::INSERT, rif_id,
+                                   port, kSwitchMac));
+    ASSIGN_OR_RETURN(*write_request.add_updates(),
+                     NeighborTableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                                         rif_id, kNeighborId, kPeerSwitchMac));
+    ASSIGN_OR_RETURN(*write_request.add_updates(),
+                     NexthopTableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                                        nexthop_id, rif_id, kNeighborId));
+    nexthop_info.push_back(WcmpAction{
+        .nexthop_id = nexthop_id,
+        .weight = 1,
+        .watch_port = port,
+    });
+  }
+
+  RETURN_IF_ERROR(
+      pdpi::SetMetadataAndSendPiWriteRequest(&session, write_request));
+  return nexthop_info;
+}
+
+// If we have only 1 nexthop then we use the set_nexthop action, but if we have
+// >1 nexthops we create a WCMP group and use the set_wcmp_group_id action.
+absl::Status ForwardAllIpTrafficToPorts(pdpi::P4RuntimeSession& session,
+                                        const pdpi::IrP4Info& ir_p4info,
+                                        absl::Span<const std::string> ports) {
+  const std::string kVrfId = "vrf-80";
+
+  RETURN_IF_ERROR(SendAllTrafficToVrf(session, ir_p4info, kVrfId));
+  ASSIGN_OR_RETURN(std::vector<WcmpAction> nexthops,
+                   CreateNextHopsForPorts(session, ir_p4info, ports));
+
+  p4::v1::WriteRequest write_request;
+
+  if (nexthops.empty()) {
+    return absl::InvalidArgumentError(
+        "Need at least 1 next hop to forward IP traffic through.");
+  } else if (nexthops.size() == 1) {
+    std::string nexthop_id = nexthops[0].nexthop_id;
+    LOG(INFO) << absl::StreamFormat(
+        "Assigning all IPv4 and IPv6 traffic from VRF '%s' to Nexthop '%s'.",
+        kVrfId, nexthop_id);
+    ASSIGN_OR_RETURN(
+        *write_request.add_updates(),
+        Ipv4TableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                        IpTableOptions{
+                            .vrf_id = kVrfId,
+                            .action = IpTableOptions::Action::kSetNextHopId,
+                            .nexthop_id = nexthop_id,
+                        }));
+    ASSIGN_OR_RETURN(
+        *write_request.add_updates(),
+        Ipv6TableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                        IpTableOptions{
+                            .vrf_id = kVrfId,
+                            .action = IpTableOptions::Action::kSetNextHopId,
+                            .nexthop_id = nexthop_id,
+                        }));
+  } else {
+    std::string wcmp_group_id = "group-1";
+    LOG(INFO) << absl::StreamFormat("Creating WCMP group '%s'.", wcmp_group_id);
+    ASSIGN_OR_RETURN(*write_request.add_updates(),
+                     WcmpGroupTableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                                          wcmp_group_id, nexthops));
+
+    LOG(INFO) << absl::StreamFormat(
+        "Assigning all IPv4 and IPv6 traffic from VRF '%s' to WCMP group '%s'.",
+        kVrfId, wcmp_group_id);
+    ASSIGN_OR_RETURN(
+        *write_request.add_updates(),
+        Ipv4TableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                        IpTableOptions{
+                            .vrf_id = kVrfId,
+                            .action = IpTableOptions::Action::kSetWcmpGroupId,
+                            .wcmp_group_id = wcmp_group_id,
+                        }));
+    ASSIGN_OR_RETURN(
+        *write_request.add_updates(),
+        Ipv6TableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                        IpTableOptions{
+                            .vrf_id = kVrfId,
+                            .action = IpTableOptions::Action::kSetWcmpGroupId,
+                            .wcmp_group_id = wcmp_group_id,
+                        }));
+  }
+
+  // Admit all traffic to L3.
+  LOG(INFO) << "Forwarding all traffic to IP routing.";
+  ASSIGN_OR_RETURN(
+      *write_request.add_updates(),
+      L3AdmitTableUpdate(ir_p4info, p4::v1::Update::INSERT,
+                         L3AdmitOptions{
+                             .priority = 2070,
+                             .dst_mac = std::make_pair("00:00:00:00:00:00",
+                                                       "01:00:00:00:00:00"),
+                         }));
+
+  return pdpi::SetMetadataAndSendPiWriteRequest(&session, write_request);
+}
+
+packetlib::Packet GetGenericIpHeadersForUdpPacket(bool use_ipv4) {
+  packetlib::Packet packet;
+
+  // Ethernet
+  packetlib::Header& ethernet = *packet.add_headers();
+  ethernet.mutable_ethernet_header()->set_ethernet_destination(kSwitchMac);
+  ethernet.mutable_ethernet_header()->set_ethernet_source("00:00:22:22:00:00");
+
+  if (use_ipv4) {
+    ethernet.mutable_ethernet_header()->set_ethertype("0x0800");
+
+    packetlib::Header& ip = *packet.add_headers();
+    ip.mutable_ipv4_header()->set_version("0x4");
+    ip.mutable_ipv4_header()->set_ihl("0x5");
+    ip.mutable_ipv4_header()->set_dscp("0x1b");
+    ip.mutable_ipv4_header()->set_ecn("0x1");
+    ip.mutable_ipv4_header()->set_identification("0x0000");
+    ip.mutable_ipv4_header()->set_flags("0x0");
+    ip.mutable_ipv4_header()->set_fragment_offset("0x0000");
+    ip.mutable_ipv4_header()->set_ttl("0x10");
+    ip.mutable_ipv4_header()->set_protocol("0x11");
+    ip.mutable_ipv4_header()->set_ipv4_source("10.0.0.1");
+    ip.mutable_ipv4_header()->set_ipv4_destination("10.0.0.2");
+  } else {
+    ethernet.mutable_ethernet_header()->set_ethertype("0x86dd");
+
+    packetlib::Header& ip = *packet.add_headers();
+    ip.mutable_ipv6_header()->set_version("0x6");
+    ip.mutable_ipv6_header()->set_dscp("0x1b");
+    ip.mutable_ipv6_header()->set_ecn("0x1");
+    ip.mutable_ipv6_header()->set_flow_label("0x12345");
+    ip.mutable_ipv6_header()->set_next_header("0x11");
+    ip.mutable_ipv6_header()->set_hop_limit("0x10");
+    ip.mutable_ipv6_header()->set_ipv6_source("2607:f8b0:11::");
+    ip.mutable_ipv6_header()->set_ipv6_destination("2607:f8b0:12::");
+  }
+  return packet;
+}
+
+struct UdpHeaderOptions {
+  std::string source_port = "0x0014";
+  std::string destination_port = "0x0015";
+  std::string checksum = "0x0000";
+};
+
+packetlib::Header GetUdpHeader(const UdpHeaderOptions& options) {
+  packetlib::Header udp;
+  udp.mutable_udp_header()->set_source_port(options.source_port);
+  udp.mutable_udp_header()->set_destination_port(options.destination_port);
+  udp.mutable_udp_header()->set_checksum(options.checksum);
+  return udp;
+}
+
+struct PtpHeaderOptions {
+  std::string transport_specific = "0x0";
+  std::string message_type = "0x0";
+  std::string reserved0 = "0x0";
+  std::string version_ptp = "0x2";  // Default to v2 which our switches support.
+  std::string domain_number = "0x00";
+  std::string reserved1 = "0x00";
+  std::string flags = "0x0000";
+  std::string correction_field = "0x0000000000000000";
+  std::string reserved2 = "0x00000000";
+  std::string source_port_identity = "0x00000000000000000000";
+  std::string sequence_id = "0x0000";
+  std::string control_field = "0x00";
+  std::string log_message_interval = "0x00";
+};
+
+packetlib::Header GetPtpHeader(const PtpHeaderOptions& options) {
+  packetlib::Header ptp;
+  ptp.mutable_ptp_header()->set_transport_specific(options.transport_specific);
+  ptp.mutable_ptp_header()->set_message_type(options.message_type);
+  ptp.mutable_ptp_header()->set_reserved0(options.reserved0);
+  ptp.mutable_ptp_header()->set_version_ptp(options.version_ptp);
+  ptp.mutable_ptp_header()->set_domain_number(options.domain_number);
+  ptp.mutable_ptp_header()->set_reserved1(options.reserved1);
+  ptp.mutable_ptp_header()->set_flags(options.flags);
+  ptp.mutable_ptp_header()->set_correction_field(options.correction_field);
+  ptp.mutable_ptp_header()->set_reserved2(options.reserved2);
+  ptp.mutable_ptp_header()->set_source_port_identity(
+      options.source_port_identity);
+  ptp.mutable_ptp_header()->set_sequence_id(options.sequence_id);
+  ptp.mutable_ptp_header()->set_control_field(options.control_field);
+  ptp.mutable_ptp_header()->set_log_message_interval(
+      options.log_message_interval);
+  return ptp;
+}
+
+absl::Status SendPacketsToSwitch(pdpi::P4RuntimeSession& session,
+                                 const pdpi::IrP4Info& ir_p4info,
+                                 absl::string_view port,
+                                 absl::Span<const packetlib::Packet> packets) {
+  // Rate limit to 500pps to avoid punt packet drops on the control switch.
+  absl::Duration kDelay = absl::Milliseconds(2);
+
+  LOG(INFO) << absl::StreamFormat("Sending %d packets to port '%s'.",
+                                  packets.size(), port);
+  for (const auto& packet : packets) {
+    ASSIGN_OR_RETURN(std::string raw_packet,
+                     packetlib::SerializePacket(packet));
+
+    if (port == kSendToIngress) {
+      RETURN_IF_ERROR(
+          InjectIngressPacket(raw_packet, ir_p4info, &session, kDelay));
+    } else {
+      RETURN_IF_ERROR(InjectEgressPacket(std::string{port}, raw_packet,
+                                         ir_p4info, &session, kDelay));
+    }
+  }
+  return absl::OkStatus();
+}
+
+struct TestPacketInfo {
+  std::string payload;
+  int32_t packet_count = 0;
+};
+
+bool UpdatePacketCountByPayload(std::vector<TestPacketInfo>& payloads,
+                                const packetlib::Packet& packet) {
+  for (auto& payload_info : payloads) {
+    if (absl::StrContains(packet.payload(), payload_info.payload)) {
+      ++payload_info.packet_count;
+      return true;
+    }
+  }
+  LOG(WARNING) << "Unexpected packet payload: " << packet.DebugString();
+  return false;
+}
+
+bool UpdatePacketCountByPayload(std::vector<TestPacketInfo>& payloads,
+                                const p4::v1::StreamMessageResponse& message) {
+  if (message.update_case() != p4::v1::StreamMessageResponse::kPacket) {
+    LOG(WARNING) << "Unexpected stream response: " << message.DebugString();
+  }
+
+  packetlib::Packet packet = packetlib::ParsePacket(message.packet().payload());
+  return UpdatePacketCountByPayload(payloads, packet);
+}
+
+TEST_P(TimestampingTestFixture, InvalidPtpPacketsAreDropped) {
+  // We use the control_port to send traffic through the front-panel ports. The
+  // SUT ports will be used to forward any IP traffic.
+  ASSERT_OK_AND_ASSIGN(std::string control_port,
+                       pins_test::GetAnyUpInterfacePortId(*control_gnmi_stub_));
+  ASSERT_OK_AND_ASSIGN(std::vector<std::string> sut_ports,
+                       pins_test::GetNUpInterfacePortIds(*sut_gnmi_stub_, 4));
+
+  // Configure the control switch to collect all packets, and the SUT to forward
+  // any IP traffic.
+  ASSERT_OK(PuntAllPacketToCpu(*control_p4rt_session_, ir_p4info_));
+  ASSERT_OK(
+      ForwardAllIpTrafficToPorts(*sut_p4rt_session_, ir_p4info_, sut_ports));
+
+  // Create 8000 packets that we expect to be dropped. We expect our switches to
+  // use PTPv2, and drop PTPv1 packets. PTPv3 doesn't exist in the standard and
+  // is invalid so it should be dropped as well.
+  std::vector<TestPacketInfo> test_packet_info = {
+      TestPacketInfo{
+          .payload = "PTPv1 packet that should be dropped (front-panel).",
+      },
+      TestPacketInfo{
+          .payload = "PTPv1 packet that should be dropped (submit_to_ingress).",
+      },
+      TestPacketInfo{
+          .payload = "PTPv3 packet that should be dropped (front-panel).",
+      },
+      TestPacketInfo{
+          .payload = "PTPv3 packet that should be dropped (submit_to_ingress).",
+      },
+  };
+  std::vector<packetlib::Packet> front_panel_packets;
+  std::vector<packetlib::Packet> submit_to_ingress_packets;
+  for (int i = 0; i < 2000; ++i) {
+    // Alternate between IPv4 and IPv6 packets.
+    packetlib::Packet ptpv1_packet =
+        GetGenericIpHeadersForUdpPacket(/*use_ipv4=*/i % 2);
+    *ptpv1_packet.add_headers() = GetUdpHeader(UdpHeaderOptions{
+        .destination_port = std::string{kPtpEventUdpDstPort},
+    });
+    *ptpv1_packet.add_headers() =
+        GetPtpHeader(PtpHeaderOptions{.version_ptp = "0x1"});
+
+    packetlib::Packet ptpv3_packet =
+        GetGenericIpHeadersForUdpPacket(/*use_ipv4=*/i % 2);
+    *ptpv3_packet.add_headers() = GetUdpHeader(UdpHeaderOptions{
+        .destination_port = std::string{kPtpEventUdpDstPort},
+    });
+    *ptpv3_packet.add_headers() =
+        GetPtpHeader(PtpHeaderOptions{.version_ptp = "0x3"});
+
+    front_panel_packets.push_back(ptpv1_packet);
+    front_panel_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[0].payload));
+
+    submit_to_ingress_packets.push_back(ptpv1_packet);
+    submit_to_ingress_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[1].payload));
+
+    front_panel_packets.push_back(ptpv3_packet);
+    front_panel_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[2].payload));
+
+    submit_to_ingress_packets.push_back(ptpv3_packet);
+    submit_to_ingress_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[3].payload));
+  }
+  ASSERT_OK(SendPacketsToSwitch(*control_p4rt_session_, ir_p4info_,
+                                control_port, front_panel_packets));
+  ASSERT_OK(SendPacketsToSwitch(*sut_p4rt_session_, ir_p4info_, kSendToIngress,
+                                submit_to_ingress_packets));
+
+  // Wait for some fixed time then collect all packets that made it through the
+  // SUT switch, and back to the control switch.
+  ASSERT_OK_AND_ASSIGN(
+      std::vector<p4::v1::StreamMessageResponse> messages,
+      control_p4rt_session_->GetAllStreamMessagesFor(absl::Seconds(10)));
+  LOG(INFO) << "Done collecting packets.";
+
+  // Verify that none of the packets which made it through are PTPv1 packets.
+  std::vector<std::string> ptpv1_packets;
+  for (const auto& message : messages) {
+    if (UpdatePacketCountByPayload(test_packet_info, message)) {
+      packetlib::Packet packet_in =
+          packetlib::ParsePacket(message.packet().payload());
+      ptpv1_packets.push_back(packet_in.DebugString());
+    }
+  }
+
+  // If we did see any PTPv1 packets store them as a test artifact to help when
+  // triaging failures.
+  if (!ptpv1_packets.empty()) {
+    absl::Status status = GetMirrorTestbed().Environment().StoreTestArtifact(
+        "ptpv1_packets_that_were_not_dropped.txt",
+        absl::StrJoin(ptpv1_packets, "\n"));
+    LOG_IF(WARNING, !status.ok())
+        << "Could not save PTPv1 packets as an artifact: " << status;
+  }
+
+  EXPECT_EQ(test_packet_info[0].packet_count, 0) << "ptpv1 front-panel ports";
+  EXPECT_EQ(test_packet_info[1].packet_count, 0) << "ptpv1 submit_to_ingress";
+  EXPECT_EQ(test_packet_info[2].packet_count, 0) << "ptpv3 front-panel ports";
+  EXPECT_EQ(test_packet_info[3].packet_count, 0) << "ptpv3 submit_to_ingress";
+}
+
+TEST_P(TimestampingTestFixture, PtpV2PacketsAreForwardedSuccessfully) {
+  // We use the control_port to send traffic through the front-panel ports. The
+  // SUT ports will be used to forward any IP traffic.
+  ASSERT_OK_AND_ASSIGN(std::string control_port,
+                       pins_test::GetAnyUpInterfacePortId(*control_gnmi_stub_));
+  ASSERT_OK_AND_ASSIGN(std::vector<std::string> sut_ports,
+                       pins_test::GetNUpInterfacePortIds(*sut_gnmi_stub_, 4));
+
+  // Configure the control switch to collect all packets, and the SUT to forward
+  // any IP traffic.
+  ASSERT_OK(PuntAllPacketToCpu(*control_p4rt_session_, ir_p4info_));
+  ASSERT_OK(
+      ForwardAllIpTrafficToPorts(*sut_p4rt_session_, ir_p4info_, sut_ports));
+
+  // Create 4000 PTPv2 packets. We will send 2000 of them through a front-panel
+  // port, and 2000 of them through submit_to_ingress. We expect all these
+  // packets to be forwarded by the SUT switch, and have an updated
+  // 'correction_field' value.
+  constexpr absl::string_view kZeroValueCorrectionField = "0x0000000000000000";
+  std::vector<TestPacketInfo> test_packet_info = {
+      TestPacketInfo{
+          .payload =
+              "Sample PTPv2 packet that should be forwarded (front-panel).",
+      },
+      TestPacketInfo{
+          .payload = "Sample PTPv2 packet that should be forwarded "
+                     "(submit_to_ingress).",
+      },
+  };
+  std::vector<packetlib::Packet> front_panel_packets;
+  std::vector<packetlib::Packet> submit_to_ingress_packets;
+  for (int i = 0; i < 2000; ++i) {
+    // Mix IPv4 and IPv6 packets.
+    packetlib::Packet packet =
+        GetGenericIpHeadersForUdpPacket(/*use_ipv4=*/i % 2);
+    *packet.add_headers() = GetUdpHeader(UdpHeaderOptions{
+        .destination_port = std::string{kPtpEventUdpDstPort},
+    });
+    *packet.add_headers() = GetPtpHeader(PtpHeaderOptions{
+        .version_ptp = "0x2",
+        .correction_field = std::string{kZeroValueCorrectionField},
+    });
+
+    front_panel_packets.push_back(packet);
+    front_panel_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[0].payload));
+    submit_to_ingress_packets.push_back(packet);
+    submit_to_ingress_packets.back().set_payload(
+        absl::Substitute("[Packet:$0] $1", i, test_packet_info[1].payload));
+  }
+  ASSERT_OK(SendPacketsToSwitch(*control_p4rt_session_, ir_p4info_,
+                                control_port, front_panel_packets));
+  ASSERT_OK(SendPacketsToSwitch(*sut_p4rt_session_, ir_p4info_, kSendToIngress,
+                                submit_to_ingress_packets));
+
+  int number_of_expected_packets =
+      front_panel_packets.size() + submit_to_ingress_packets.size();
+  ASSERT_OK(control_p4rt_session_->HandleNextNStreamMessages(
+      [&](const p4::v1::StreamMessageResponse& message) {
+        if (message.update_case() != p4::v1::StreamMessageResponse::kPacket) {
+          LOG(WARNING) << "Unexpected stream response: "
+                       << message.DebugString();
+        }
+        packetlib::Packet packet =
+            packetlib::ParsePacket(message.packet().payload());
+
+        // First verify that this packet has the payload we sent with it.
+        bool correct_payload =
+            UpdatePacketCountByPayload(test_packet_info, message);
+        if (!correct_payload) return false;
+
+        // Then verify that the correction field has been changed. We can't
+        // predict what value to expect so we simply check that it is not 0.
+        if (packet.headers_size() < 4 ||
+            packet.headers(3).ptp_header().correction_field() ==
+                kZeroValueCorrectionField) {
+          static bool first_failure = false;  // only report the first failure.
+          if (!first_failure) {
+            ADD_FAILURE() << "PTPv2 correction field was not updated:\n"
+                          << packet.DebugString();
+            first_failure = true;
+          }
+        }
+
+        // So long as we see a packet with our expected payload we return true.
+        // Otherwise, this test will stall until the timeout waiting for the
+        // "correct" packet.
+        return correct_payload;
+      },
+      number_of_expected_packets, /*timeout=*/absl::Minutes(1)));
+  LOG(INFO) << "Done collecting packets.";
+
+  EXPECT_EQ(test_packet_info[0].packet_count, front_panel_packets.size());
+  EXPECT_EQ(test_packet_info[1].packet_count, submit_to_ingress_packets.size());
+}
+
+}  // namespace
+}  // namespace pins

--- a/tests/forwarding/timestamping_test.h
+++ b/tests/forwarding/timestamping_test.h
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef PINS_TESTS_FORWARDING_TIMESTAMPING_TEST_H_
+#define PINS_TESTS_FORWARDING_TIMESTAMPING_TEST_H_
+
+#include <memory>
+
+#include "glog/logging.h"
+#include "gmock/gmock.h"
+#include "gutil/status_matchers.h"
+#include "p4_pdpi/ir.h"
+#include "p4_pdpi/ir.pb.h"
+#include "p4_pdpi/p4_runtime_session.h"
+#include "proto/gnmi/gnmi.grpc.pb.h"
+#include "tests/lib/switch_test_setup_helpers.h"
+#include "thinkit/mirror_testbed_fixture.h"
+
+namespace pins {
+
+class TimestampingTestFixture : public thinkit::MirrorTestbedFixture {
+ protected:
+  void SetUp() override {
+    thinkit::MirrorTestbedFixture::SetUp();
+    LOG(INFO) << "Control switch: "
+              << GetMirrorTestbed().ControlSwitch().ChassisName();
+    LOG(INFO) << "SUT: " << GetMirrorTestbed().Sut().ChassisName();
+
+    // Timestamping test assumes a gNMI config is already installed on the
+    // switch.
+    pins_test::PinsConfigView config{
+        .p4info = p4_info(),
+    };
+    ASSERT_OK(pins_test::ConfigureSwitchPair(GetMirrorTestbed().Sut(), config,
+                                             GetMirrorTestbed().ControlSwitch(),
+                                             config));
+
+    // Open gNMI and P4RT connections for the tests to use.
+    ASSERT_OK_AND_ASSIGN(sut_p4rt_session_, pdpi::P4RuntimeSession::Create(
+                                                GetMirrorTestbed().Sut()));
+    ASSERT_OK_AND_ASSIGN(
+        control_p4rt_session_,
+        pdpi::P4RuntimeSession::Create(GetMirrorTestbed().ControlSwitch()));
+    ASSERT_OK_AND_ASSIGN(sut_gnmi_stub_,
+                         GetMirrorTestbed().Sut().CreateGnmiStub());
+    ASSERT_OK_AND_ASSIGN(control_gnmi_stub_,
+                         GetMirrorTestbed().ControlSwitch().CreateGnmiStub());
+
+    ASSERT_OK_AND_ASSIGN(ir_p4info_, pdpi::CreateIrP4Info(p4_info()));
+  }
+
+  std::unique_ptr<gnmi::gNMI::StubInterface> sut_gnmi_stub_;
+  std::unique_ptr<gnmi::gNMI::StubInterface> control_gnmi_stub_;
+  std::unique_ptr<pdpi::P4RuntimeSession> sut_p4rt_session_;
+  std::unique_ptr<pdpi::P4RuntimeSession> control_p4rt_session_;
+
+  pdpi::IrP4Info ir_p4info_;
+};
+
+}  // namespace pins
+
+#endif  // PINS_TESTS_FORWARDING_TIMESTAMPING_TEST_H_


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 749 targets (1 packages loaded, 79 targets configured).
INFO: Found 749 targets...
INFO: From Compiling tests/lib/p4rt_fixed_table_programming_helper_test.cc:
tests/lib/p4rt_fixed_table_programming_helper_test.cc: In function 'bool pins::{anonymous}::HasSubstringsInOrder(absl::lts_20240116::string_view, std::vector<std::__cxx11::basic_string<char> >)':
tests/lib/p4rt_fixed_table_programming_helper_test.cc:688:18: warning: comparison of integer expressions of different signedness: 'int' and 'const std::basic_string_view<char>::size_type' {aka 'const long unsigned int'} [-Wsign-compare]
  688 |     if (position == str.npos) return false;
tests/lib/p4rt_fixed_table_programming_helper_test.cc: In instantiation of 'bool pins::{anonymous}::HasReplicaMatcherP2<port_type, instance_type>::gmock_Impl<arg_type>::MatchAndExplain(const arg_type&, testing::MatchResultListener*) const [with arg_type = const p4::v1::Update&; port_type = const char*; instance_type = int]':
tests/lib/p4rt_fixed_table_programming_helper_test.cc:97:1:   required from here
tests/lib/p4rt_fixed_table_programming_helper_test.cc:102:54: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'const int' [-Wsign-compare]
  102 |     if (replica.port() == port && replica.instance() == instance) {
      |                                   ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
tests/lib/p4rt_fixed_table_programming_helper_test.cc: In instantiation of 'bool pins::{anonymous}::HasGroupIdMatcherP<id_type>::gmock_Impl<arg_type>::MatchAndExplain(const arg_type&, testing::MatchResultListener*) const [with arg_type = const p4::v1::Update&; id_type = int]':
tests/lib/p4rt_fixed_table_programming_helper_test.cc:109:1:   required from here
tests/lib/p4rt_fixed_table_programming_helper_test.cc:113:33: warning: comparison of integer expressions of different signedness: 'uint32_t' {aka 'unsigned int'} and 'const int' [-Wsign-compare]
  110 |   if (arg.entity()
      |       ~~~~~~~~~~~~               
  111 |           .packet_replication_engine_entry()
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  112 |           .multicast_group_entry()
      |           ~~~~~~~~~~~~~~~~~~~~~~~~
  113 |           .multicast_group_id() == id) {
      |           ~~~~~~~~~~~~~~~~~~~~~~^~~~~
INFO: From Compiling tests/forwarding/l3_admit_test.cc:
tests/sflow/sflow_test.cc:2514:5: note: in expansion of macro 'EXPECT_OK'
 2514 |     EXPECT_OK(pdpi::ClearTableEntries(control_p4_session_.get()));
      |     ^~~~~~~~~
./p4_pdpi/p4_runtime_session.h:413:14: note: declared here
  413 | absl::Status ClearTableEntries(P4RuntimeSession *session);
      |              ^~~~~~~~~~~~~~~~~
In file included from ./p4_pdpi/netaddr/network_address.h:28,
                 from ./p4_pdpi/netaddr/ipv4_address.h:22,
                 from ./lib/ixia_helper.h:31,
                 from tests/sflow/sflow_test.cc:54:
./p4_pdpi/string_encodings/hex_string.h: In instantiation of 'std::string pdpi::BitsetToHexString(const std::bitset<_Nb>&) [with long unsigned int num_bits = 48; std::string = std::__cxx11::basic_string<char>]':
./p4_pdpi/netaddr/network_address.h:85:67:   required from 'std::string netaddr::NetworkAddress<num_bits, T>::ToHexString() const [with long unsigned int num_bits = 48; T = netaddr::MacAddress; std::string = std::__cxx11::basic_string<char>]'
tests/sflow/sflow_test.cc:1515:43:   required from here
./p4_pdpi/string_encodings/hex_string.h:95:24: warning: comparison of integer expressions of different signedness: 'int' and 'long unsigned int' [-Wsign-compare]
   95 |       int kth_bit = (k < num_bits) ? bitset[k] : 0; // Implicit bits are 0.
      |                     ~~~^~~~~~~~~~~
tests/sflow/sflow_test.cc: At global scope:
tests/sflow/sflow_test.cc:685:29: warning: 'absl::lts_20240116::StatusOr<std::__cxx11::basic_string<char> > pins::{anonymous}::GetPortSpeed(absl::lts_20240116::string_view, gnmi::gNMI::StubInterface*)' defined but not used [-Wunused-function]
  685 | absl::StatusOr<std::string> GetPortSpeed(absl::string_view iface,
      |                             ^~~~~~~~~~~~
INFO: Elapsed time: 126.030s, Critical Path: 104.78s
INFO: 25 processes: 6 internal, 19 linux-sandbox.
INFO: Build completed successfully, 25 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 749 targets (0 packages loaded, 9 targets configured).
INFO: Found 520 targets and 229 test targets...
INFO: Elapsed time: 405.625s, Critical Path: 268.87s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 2.8s
//dvaas:dataplane_validation_test                                        PASSED in 0.0s
//dvaas:port_id_map_test                                                 PASSED in 5.7s
//dvaas:test_run_validation_golden_test                                  PASSED in 1.5s
//dvaas:test_run_validation_test                                         PASSED in 2.8s
//dvaas:test_run_validation_test_runner                                  PASSED in 1.0s
//dvaas:test_vector_stats_diff_test                                      PASSED in 1.5s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.5s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 1.4s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 1.3s
//gutil:collections_test                                                 PASSED in 0.9s
//gutil:io_test                                                          PASSED in 0.8s
//gutil:proto_matchers_test                                              PASSED in 0.9s
//gutil:proto_ordering_test                                              PASSED in 0.9s
//gutil:proto_test                                                       PASSED in 0.9s
//gutil:status_matchers_test                                             PASSED in 0.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.1s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.9s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.7s
//tests/forwarding:hash_statistics_util_test                             PASSED in 3.3s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.8s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.0s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 1.2s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.6s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.7s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.7s
//thinkit:generic_testbed_test                                           PASSED in 2.6s
//thinkit:mock_control_device_test                                       PASSED in 1.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.1s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.3s
//thinkit:mock_switch_test                                               PASSED in 2.5s
//thinkit:mock_test_environment_test                                     PASSED in 0.3s
//thinkit:switch_test                                                    PASSED in 2.1s
//tests/lib:packet_generator_test                                        PASSED in 129.1s
  Stats over 4 runs: max = 129.1s, min = 74.2s, avg = 113.9s, dev = 23.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.9s
  Stats over 5 runs: max = 2.9s, min = 1.5s, avg = 2.2s, dev = 0.5s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 101.4s
  Stats over 50 runs: max = 101.4s, min = 1.4s, avg = 7.0s, dev = 17.7s

Executed 229 out of 229 tests: 229 tests pass.
