### PR TITLE
[Thinkit/Tests] Add more logging in NSF upgrade test to make it easier to track the progress of the test and to identify any potential issues.

### DIFF
--- a/tests/integration/system/nsf/interfaces/image_config_params.h
+++ b/tests/integration/system/nsf/interfaces/image_config_params.h
@@ -22,10 +22,11 @@
 
 namespace pins_test {
 
-// Struct to hold image label, config label, and config parameters to be
-// injected in PINs NSF integration tests.
+// Struct to hold image label, image version, config label and config parameters
+// to be injected in PINs NSF integration tests.
 struct ImageConfigParams {
   std::string image_label;
+  std::string image_version;
   std::string config_label;
   std::string gnmi_config;
   p4::config::v1::P4Info p4_info;

--- a/tests/integration/system/nsf/upgrade_test.cc
+++ b/tests/integration/system/nsf/upgrade_test.cc
@@ -24,6 +24,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
@@ -121,8 +122,11 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   continue_on_failure = false;
   absl::Status overall_status;
 
-  LOG(INFO) << "Initiating NSF Upgrade from: " << curr_image_config.image_label
-            << " to: " << next_image_config.image_label;
+  std::string upgrade_path = absl::StrFormat(
+      "NSF Upgrade from %s (%s) to %s (%s)", curr_image_config.image_version,
+      curr_image_config.image_label, next_image_config.image_version,
+      next_image_config.image_label);
+  LOG(INFO) << "Initiating " << upgrade_path;
 
   std::vector<std::string> interfaces_to_check;
   RETURN_IF_ERROR(ValidateTestbedState(
@@ -148,11 +152,18 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
     AppendErrorStatus(overall_status,
                       absl::InternalError(absl::StrFormat(
                           "Failed to take P4 snapshot before programming flows "
-                          "and starting traffic")));
+                          "and starting traffic: %s",
+                          status_or_p4_snapshot1.status().message())));
   } else {
     p4flow_snapshot1 = status_or_p4_snapshot1.value();
-    if (!SaveP4FlowSnapshot(testbed_, p4flow_snapshot1,
-                            "p4flow_snapshot1_before_programming_flows.txt")
+    if (!SaveP4FlowSnapshot(
+             testbed_, p4flow_snapshot1,
+             absl::StrCat(curr_image_config.image_version, "_",
+                          next_image_config.image_version,
+                          "_p4flow_snapshot_before_programming_flows_",
+                          absl::FormatTime("%H_%M_%S", absl::Now(),
+                                           absl::LocalTimeZone()),
+                          ".txt"))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot before programming flows";
     }
@@ -204,21 +215,25 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   ReadResponse p4flow_snapshot2;
   auto status_or_p4_snapshot2 = TakeP4FlowSnapshot(testbed_);
   if (!status_or_p4_snapshot2.ok()) {
-    AppendErrorStatus(overall_status,
-                      absl::InternalError(absl::StrFormat(
-                          "Failed to take P4 snapshot before programming flows "
-                          "and starting traffic")));
+    AppendErrorStatus(
+        overall_status,
+        absl::InternalError(absl::StrFormat(
+            "Failed to take P4 snapshot before Upgrade and NSF reboot: %s",
+            status_or_p4_snapshot2.status().message())));
   } else {
     p4flow_snapshot2 = status_or_p4_snapshot2.value();
     if (!SaveP4FlowSnapshot(
              testbed_, p4flow_snapshot2,
-             "p4flow_snapshot2_before_upgrade_and_nsf_reboot.txt")
+             absl::StrCat(curr_image_config.image_version, "_",
+                          next_image_config.image_version,
+                          "_p4flow_snapshot_before_upgrade_and_nsf_reboot_",
+                          absl::FormatTime("%H_%M_%S", absl::Now(),
+                                           absl::LocalTimeZone()),
+                          ".txt"))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot before upgrade and NSF reboot";
     }
   }
-
-  LOG(INFO) << "Starting NSF Upgrade";
 
   ASSIGN_OR_RETURN(auto sut_gnmi_stub, sut.CreateGnmiStub());
 
@@ -227,6 +242,8 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
       GetPinsSoftwareComponentInfo(*sut_gnmi_stub),
       _.LogError() << "Failed to get pins software component info before "
                       "upgrade and reboot");
+
+  LOG(INFO) << "Starting " << upgrade_path;
 
   // Copy image to the switch for installation.
   ASSIGN_OR_RETURN(
@@ -288,9 +305,7 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
                           status.message())));
   }
 
-  LOG(INFO) << "NSF Reboot completed between %s and %s"
-            << curr_image_config.image_label << " and "
-            << next_image_config.image_label;
+  LOG(INFO) << upgrade_path << ": NSF Reboot completed";
 
   status = ValidateComponents(
       &ComponentValidator::OnNsfReboot, component_validators_,
@@ -308,14 +323,21 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   ReadResponse p4flow_snapshot3;
   auto status_or_p4_snapshot3 = TakeP4FlowSnapshot(testbed_);
   if (!status_or_p4_snapshot3.ok()) {
-    AppendErrorStatus(overall_status,
-                      absl::InternalError(absl::StrFormat(
-                          "Failed to take P4 snapshot before programming flows "
-                          "and starting traffic")));
+    AppendErrorStatus(
+        overall_status,
+        absl::InternalError(absl::StrFormat(
+            "Failed to take P4 snapshot after Upgrade and NSF reboot: %s",
+            status_or_p4_snapshot3.status().message())));
   } else {
     p4flow_snapshot3 = status_or_p4_snapshot3.value();
-    if (!SaveP4FlowSnapshot(testbed_, p4flow_snapshot3,
-                            "p4flow_snapshot3_after_upgrade_and_nsf_reboot.txt")
+    if (!SaveP4FlowSnapshot(
+             testbed_, p4flow_snapshot3,
+             absl::StrCat(curr_image_config.image_version, "_",
+                          next_image_config.image_version,
+                          "_p4flow_snapshot_after_upgrade_and_nsf_reboot_",
+                          absl::FormatTime("%H_%M_%S", absl::Now(),
+                                           absl::LocalTimeZone()),
+                          ".txt"))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot after upgrade and NSF reboot";
     }
@@ -323,33 +345,35 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
 
   switch (scenario) {
     case NsfUpgradeScenario::kNoConfigPush:
-      LOG(INFO) << "Proceeding with no config push scenario";
+      LOG(INFO) << upgrade_path << ": Proceeding with no config push scenario";
       RETURN_IF_ERROR(ValidateTestbedState(
           testbed_, *ssh_client_, &curr_image_config,
           enable_interface_validation_during_nsf, interfaces_to_check));
       break;
     case NsfUpgradeScenario::kOnlyConfigPush:
-      LOG(INFO) << "Proceeding with only config push";
+      LOG(INFO) << upgrade_path << ": Proceeding with only config push";
 
       status = PushConfigAndValidate(next_image_config,
                                      enable_interface_validation_during_nsf);
       if (!status.ok()) {
-        AppendErrorStatus(
-            overall_status,
-            absl::InternalError(absl::StrFormat(
-                "PushConfigAndValidate failed after NSF reboot %s",
-                status.message())));
+        AppendErrorStatus(overall_status,
+                          absl::InternalError(absl::StrFormat(
+                              "PushConfigAndValidate failed during "
+                              "ConfigPushOnly scenario: %s",
+                              status.message())));
       }
 
       break;
     case NsfUpgradeScenario::kConfigPushAfterAclFlowProgram:
-      LOG(INFO) << "Proceeding with config push after ACL flow program";
+      LOG(INFO) << upgrade_path
+                << ": Proceeding with config push after ACL flow program";
 
       status = ProgramAclFlows(GetSut(testbed_), curr_image_config.p4_info);
       if (!status.ok()) {
         AppendErrorStatus(overall_status,
                           absl::InternalError(absl::StrFormat(
-                              "ProgramAclFlows failed after NSF reboot %s",
+                              "ProgramAclFlows failed during "
+                              "ConfigPushAfterAclFlowProgram scenario: %s",
                               status.message())));
       }
 
@@ -358,22 +382,23 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
       if (!status.ok()) {
         AppendErrorStatus(overall_status,
                           absl::InternalError(absl::StrFormat(
-                              "PushConfigAndValidate failed after ACL flow "
-                              "program %s",
+                              "PushConfigAndValidate failed during "
+                              "ConfigPushAfterAclFlowProgram scenario: %s",
                               status.message())));
       }
 
       break;
 
     case NsfUpgradeScenario::kConfigPushBeforeAclFlowProgram:
-      LOG(INFO) << "Proceeding with config push before ACL flow program";
+      LOG(INFO) << upgrade_path
+                << ": Proceeding with config push before ACL flow program";
       status = PushConfigAndValidate(next_image_config,
                                      enable_interface_validation_during_nsf);
       if (!status.ok()) {
         AppendErrorStatus(overall_status,
                           absl::InternalError(absl::StrFormat(
-                              "PushConfigAndValidate failed before ACL flow "
-                              "program %s",
+                              "PushConfigAndValidate failed during "
+                              "ConfigPushBeforeAclFlowProgram scenario: %s",
                               status.message())));
       }
 
@@ -381,8 +406,8 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
       if (!status.ok()) {
         AppendErrorStatus(overall_status,
                           absl::InternalError(absl::StrFormat(
-                              "ProgramAclFlows failed before ACL flow "
-                              "program %s",
+                              "ProgramAclFlows failed during "
+                              "ConfigPushBeforeAclFlowProgram scenario: %s",
                               status.message())));
       }
 
@@ -409,7 +434,7 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   // support traffic validation before stopping the traffic. This is a
   // good-to-have feature and we will update the skeleton to validate traffic
   // while injection is ongoing once this feature is available in DVaaS.
-  LOG(INFO) << "Validating the traffic";
+  LOG(INFO) << upgrade_path << ": Validating the traffic";
 
   status = traffic_helper_->ValidateTraffic(
       testbed_, next_image_config.max_acceptable_outage);
@@ -456,46 +481,80 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   ReadResponse p4flow_snapshot4;
   auto status_or_p4_snapshot4 = TakeP4FlowSnapshot(testbed_);
   if (!status_or_p4_snapshot4.ok()) {
-    AppendErrorStatus(overall_status,
-                      absl::InternalError(absl::StrFormat(
-                          "Failed to take P4 snapshot before programming flows "
-                          "and starting traffic")));
+    AppendErrorStatus(
+        overall_status,
+        absl::InternalError(absl::StrFormat(
+            "Failed to take P4 snapshot after cleaning up flows: %s",
+            status_or_p4_snapshot4.status().message())));
   } else {
     p4flow_snapshot4 = status_or_p4_snapshot4.value();
-    if (!SaveP4FlowSnapshot(testbed_, p4flow_snapshot4,
-                            "p4flow_snapshot4_after_clearing_flows.txt")
+    if (!SaveP4FlowSnapshot(
+             testbed_, p4flow_snapshot4,
+             absl::StrCat(curr_image_config.image_version, "_",
+                          next_image_config.image_version,
+                          "_p4flow_snapshot_after_clearing_flows_",
+                          absl::FormatTime("%H_%M_%S", absl::Now(),
+                                           absl::LocalTimeZone()),
+                          ".txt"))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot after clearing flows";
     }
   }
 
   if (status_or_p4_snapshot1.ok() && status_or_p4_snapshot4.ok()) {
-    LOG(INFO) << "Comparing P4 snapshots - Before Programming Flows Vs After "
+    LOG(INFO) << upgrade_path
+              << ": Comparing P4 snapshots - Before Programming Flows Vs After "
                  "Clearing Flows";
     status = CompareP4FlowSnapshots(p4flow_snapshot1, p4flow_snapshot4);
     if (!status.ok()) {
-      AppendErrorStatus(overall_status, absl::InternalError(absl::StrFormat(
-                                            "CompareP4FlowSnapshots failed %s",
-                                            status.message())));
+      GetTestEnvironment(testbed_)
+          .StoreTestArtifact(
+              absl::StrCat(
+                  curr_image_config.image_version, "_",
+                  next_image_config.image_version,
+                  "_compare_p4flow_snapshot_before_programming_flows_and_after_"
+                  "clearing_flows_",
+                  absl::FormatTime("%H_%M_%S", absl::Now(),
+                                   absl::LocalTimeZone()),
+                  ".txt"),
+              status.message())
+          .IgnoreError();
+      AppendErrorStatus(overall_status,
+                        absl::InternalError(absl::StrFormat(
+                            "Comparing P4 snapshots - Before Programming Flows "
+                            "Vs After Clearing Flows failed")));
     }
   }
 
   if (status_or_p4_snapshot2.ok() && status_or_p4_snapshot3.ok()) {
-    LOG(INFO) << "Comparing P4 snapshots - Before Upgrade + NSF Reboot Vs."
+    LOG(INFO) << upgrade_path
+              << ": Comparing P4 snapshots - Before Upgrade + NSF Reboot Vs."
                  "After Upgrade + NSF Reboot";
     status = CompareP4FlowSnapshots(p4flow_snapshot2, p4flow_snapshot3);
     if (!status.ok()) {
-      AppendErrorStatus(overall_status, absl::InternalError(absl::StrFormat(
-                                            "CompareP4FlowSnapshots failed %s",
-                                            status.message())));
+      GetTestEnvironment(testbed_)
+          .StoreTestArtifact(
+              absl::StrCat(curr_image_config.image_version, "_",
+                           next_image_config.image_version,
+                           "_compare_p4flow_snapshot_before_upgrade_nsf_reboot_"
+                           "and_after_"
+                           "upgrade_nsf_reboot_",
+                           absl::FormatTime("%H_%M_%S", absl::Now(),
+                                            absl::LocalTimeZone()),
+                           ".txt"),
+              status.message())
+          .IgnoreError();
+      AppendErrorStatus(overall_status,
+                        absl::InternalError(absl::StrFormat(
+                            "Comparing P4 snapshots - Before Upgrade + NSF "
+                            "Reboot Vs After Upgrade + NSF Reboot failed")));
     }
   }
 
-  LOG(INFO) << "NSF Upgrade from: " << curr_image_config.image_label
-            << " to: " << next_image_config.image_label << " is complete.";
+  LOG(INFO) << upgrade_path << " is complete.";
 
   if (!overall_status.ok()) {
-    LOG(ERROR) << "Failures encountered in NSFUpgradeOrReboot: "
+    LOG(ERROR) << "Failures encountered during " << upgrade_path << ": "
                << overall_status;
     continue_on_failure = true;
   }
@@ -534,8 +593,6 @@ TEST_P(NsfUpgradeTest, UpgradeAndReboot) {
       image_config_param->config_label =
           image_config_params.begin()->config_label;
       image_config_param->p4_info = image_config_params.begin()->p4_info;
-      image_config_param->max_acceptable_outage =
-          image_config_params.begin()->max_acceptable_outage;
     }
   }
 
@@ -548,25 +605,42 @@ TEST_P(NsfUpgradeTest, UpgradeAndReboot) {
                                     image_config_params.front()));
 
   bool continue_on_failure;
+  std::vector<std::string> error_msgs;
+  absl::Status upgrade_status;
+  ImageConfigParams curr_image_config_param;
+  ImageConfigParams next_image_config_param;
   // N - 1 to N upgrades
   for (auto image_config_param = image_config_params.begin();
        image_config_param + 1 != image_config_params.end();
        ++image_config_param) {
-    absl::Status status = (NsfUpgradeOrReboot(
-        scenario, *image_config_param, *(image_config_param + 1),
-        GetParam().enable_interface_validation_during_nsf,
-        continue_on_failure));
-    if (!status.ok() && !continue_on_failure) {
-      FAIL() << "NsfUpgradeOrReboot failed between"
-             << image_config_param->image_label << "and"
-             << (image_config_param + 1)->image_label << "with" << status;
+    curr_image_config_param = *image_config_param;
+    next_image_config_param = *(image_config_param + 1);
+    upgrade_status = NsfUpgradeOrReboot(
+        scenario, curr_image_config_param, next_image_config_param,
+        GetParam().enable_interface_validation_during_nsf, continue_on_failure);
+    if (!upgrade_status.ok()) {
+      error_msgs.push_back(absl::StrFormat(
+          "%s -> %s: %s", curr_image_config_param.image_version,
+          next_image_config_param.image_version, upgrade_status.message()));
+      if (!continue_on_failure) {
+        FAIL() << absl::StrJoin(error_msgs, "\n");
+      }
     }
   }
 
   // N to N upgrade
-  ASSERT_OK(NsfUpgradeOrReboot(
-      scenario, image_config_params.back(), image_config_params.back(),
-      GetParam().enable_interface_validation_during_nsf, continue_on_failure));
+  curr_image_config_param = image_config_params.back();
+  upgrade_status = NsfUpgradeOrReboot(
+      scenario, curr_image_config_param, curr_image_config_param,
+      GetParam().enable_interface_validation_during_nsf, continue_on_failure);
+  if (!upgrade_status.ok()) {
+    error_msgs.push_back(absl::StrFormat(
+        "%s -> %s: %s", curr_image_config_param.image_version,
+        curr_image_config_param.image_version, upgrade_status.message()));
+  }
+  if (!error_msgs.empty()) {
+    FAIL() << absl::StrJoin(error_msgs, "\n");
+  }
 }
 
 }  // namespace pins_test

--- a/tests/integration/system/nsf/upgrade_test.h
+++ b/tests/integration/system/nsf/upgrade_test.h
@@ -49,6 +49,8 @@ class NsfUpgradeTest : public testing::TestWithParam<NsfTestParams> {
   // Note: In case the flow programmer returns a gNMI config, then that will
   // override the `next_image_config.gnmi_config` and will used for subsequent
   // validations.
+  // A boolean `continue_on_failure` is passed as reference to continue even in
+  // case of failures during upgrade.
   absl::Status NsfUpgradeOrReboot(NsfUpgradeScenario scenario,
                                   ImageConfigParams &curr_image_config,
                                   ImageConfigParams &next_image_config,


### PR DESCRIPTION
Keyword Check:
/tests_sonic-pins/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 754 targets (0 packages loaded, 0 targets configured).
INFO: Found 754 targets...
INFO: From Compiling tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc:
tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc: In member function 'virtual void pins_test::NsfAclFlowCoverageTestFixture_NsfAclFlowCoverageTest_Test::TestBody()':
tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc:51:29: warning: unused variable 'environment' [-Wunused-variable]
   51 |   thinkit::TestEnvironment &environment = GetTestEnvironment(testbed_);
      |                             ^~~~~~~~~~~
INFO: From Compiling tests/gnoi/bert_tests.cc:
tests/gnoi/bert_tests.cc: In function 'void bert::{anonymous}::GetAndVerifyBertResultsWithAdminDownInterfaces(const gnoi::diag::StartBERTRequest&, const gnoi::diag::GetBERTResultResponse&, const std::vector<std::__cxx11::basic_string<char> >&, const std::vector<std::__cxx11::basic_string<char> >&, absl::lts_20240116::Duration)':
tests/gnoi/bert_tests.cc:545:30: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  545 |   for (unsigned idx = 0; idx < result_response.per_port_responses_size();
      |                          ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/gnoi/bert_tests.cc: In function 'std::vector<std::__cxx11::basic_string<char> > bert::{anonymous}::SelectNInterfacesFromList(int, std::vector<std::__cxx11::basic_string<char> >)':
tests/gnoi/bert_tests.cc:644:25: warning: comparison of integer expressions of different signedness: 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  644 |   if (interfaces.size() < port_count_to_select) {
      |       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
INFO: From Compiling tests/sflow/sflow_test.cc:
In file included from ./gutil/collections.h:29,
                 from tests/sflow/sflow_test.cc:49:
tests/sflow/sflow_test.cc: In function 'absl::lts_20240116::Status pins::{anonymous}::SetUpAclPunt(pdpi::P4RuntimeSession&, const pdpi::IrP4Info&, int)':
tests/sflow/sflow_test.cc:200:46: warning: 'absl::lts_20240116::StatusOr<p4::v1::TableEntry> pdpi::PartialPdTableEntryToPiTableEntry(const IrP4Info&, const google::protobuf::Message&, const TranslationOptions&)' is deprecated: Use PdTableEntryToPiEntity instead [-Wdeprecated-declarations]
tests/qos/cpu_qos_test.cc: In member function 'virtual void pins_test::{anonymous}::CpuQosTestWithoutIxia_P4CpuQueueMappingByNameIsCorrect_Test::TestBody()':
tests/qos/cpu_qos_test.cc:1268:66: warning: 'absl::lts_20240116::StatusOr<std::pair<std::unique_ptr<pdpi::P4RuntimeSession>, std::unique_ptr<pdpi::P4RuntimeSession> > > pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(thinkit::Switch&, thinkit::Switch&, const std::optional<std::basic_string_view<char> >&, const std::optional<p4::config::v1::P4Info>&, const pdpi::P4RuntimeSessionOptionalArgs&)' is deprecated: Use `ConfigureSwitchPair` instead, since this function works only for mirror testbeds. [-Wdeprecated-declarations]
 1268 |       pins_test::ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 1269 |           Sut(), ControlSwitch(), GetParam().gnmi_config, p4info));
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
./gutil/status_matchers.h:63:43: note: in definition of macro 'ASSERT_OK_AND_ASSIGN'
   63 |   auto __ASSIGN_OR_RETURN_VAL(__LINE__) = expression;                          \
      |                                           ^~~~~~~~~~
./tests/lib/switch_test_setup_helpers.h:132:1: note: declared here
  132 | ConfigureSwitchPairAndReturnP4RuntimeSessionPair(
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO: Elapsed time: 295.798s, Critical Path: 226.69s
INFO: 23 processes: 1 internal, 22 linux-sandbox.
INFO: Build completed successfully, 23 total actions



Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 754 targets (0 packages loaded, 0 targets configured).
INFO: Found 525 targets and 229 test targets...
INFO: Elapsed time: 308.058s, Critical Path: 160.85s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.7s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 17.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 1.3s
//dvaas:test_run_validation_test                                         PASSED in 17.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 1.3s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.9s
//dvaas:test_vector_stats_test                                           PASSED in 0.2s
//dvaas:test_vector_test                                                 PASSED in 15.6s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.1s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 1.1s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.9s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.3s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 7.3s
//thinkit:bazel_test_environment_test                                    PASSED in 0.8s
//thinkit:generic_testbed_test                                           PASSED in 1.4s
//thinkit:mock_control_device_test                                       PASSED in 0.9s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.0s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.0s
//tests/lib:packet_generator_test                                        PASSED in 66.1s
  Stats over 4 runs: max = 66.1s, min = 62.8s, avg = 64.6s, dev = 1.3s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.0s, avg = 1.3s, dev = 0.4s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 47.9s
  Stats over 50 runs: max = 47.9s, min = 1.1s, avg = 5.2s, dev = 12.5s

Executed 229 out of 229 tests: 229 tests pass.
