### PR TITLE
[Thinkit/Tests] Remove all occurrences of Parse Packet And Fill In Computed Fields.

### DIFF
--- a/tests/forwarding/l3_multicast_test.cc
+++ b/tests/forwarding/l3_multicast_test.cc
@@ -384,10 +384,12 @@ absl::StatusOr<std::vector<dvaas::PacketTestVector>> BuildTestVectors(
         .RegisterValue("@decremented_ttl", "0x3f")
         .RegisterValue("@ipv4_dst", ipv4_address.ToString())
         .RegisterValue("@ipv6_dst", ipv6_address.ToString())
-        .RegisterValue("@payload_ipv4", dvaas::MakeTestPacketTagFromUniqueId(
-                                            unique_payload_ids++))
-        .RegisterValue("@payload_ipv6", dvaas::MakeTestPacketTagFromUniqueId(
-                                            unique_payload_ids++));
+        .RegisterValue(
+            "@payload_ipv4",
+            dvaas::MakeTestPacketPayloadFromUniqueId(unique_payload_ids++))
+        .RegisterValue(
+            "@payload_ipv6",
+            dvaas::MakeTestPacketPayloadFromUniqueId(unique_payload_ids++));
     // Build headers.
     repo.RegisterSnippetOrDie<packetlib::Header>("@ethernet_ipv4", R"pb(
           ethernet_header {
@@ -796,7 +798,13 @@ TEST_P(L3MulticastTestFixture, BasicReplicationProgrammingWithAclRedirect) {
   EXPECT_OK(validation_result.HasSuccessRateOfAtLeast(1.0));
 }
 
-TEST_P(L3MulticastTestFixture, DISABLED_ConfirmFixedDelayProgramming) {
+TEST_P(L3MulticastTestFixture, ConfirmFixedDelayProgramming) {
+  if (!pins::TableHasMatchField(ir_p4info_, "acl_egress_l2_table",
+                                 "src_mac")) {
+    GTEST_SKIP()
+        << "Skipping because match field 'src_mac' is not available in table "
+        << "'acl_egress_l2_table'";
+  }
 
   thinkit::MirrorTestbed& testbed =
       GetParam().mirror_testbed->GetMirrorTestbed();
@@ -835,8 +843,8 @@ TEST_P(L3MulticastTestFixture, DISABLED_ConfirmFixedDelayProgramming) {
   // Replicas to be dropped will rewrite their source MAC address to be the
   // "drop" MAC address.
   ASSERT_OK_AND_ASSIGN(auto proto_entry,
-                       gutil::ParseTextProto<pdpi::IrTableEntry>(
-                           R"pb(table_name: "acl_egress_table"
+                       gutil::ParseTextProto<pdpi::IrTableEntry>(gutil::ParseTextProto<pdpi::IrTableEntry>(
+                           R"pb(table_name: "acl_egress_l2_table"
                                 priority: 1
                                 matches {
                                   name: "src_mac"
@@ -974,7 +982,7 @@ TEST_P(L3MulticastTestFixture, ReplicatingNTimesToSamePortProducesNCopies) {
       .RegisterValue("@decremented_hop_limit", "0x4f")
       .RegisterValue("@decremented_ttl", "0x3f")
       .RegisterValue("@ipv4_dst", input_ipv4_address.ToString())
-      .RegisterValue("@payload_ipv4", dvaas::MakeTestPacketTagFromUniqueId(
+      .RegisterValue("@payload_ipv4", dvaas::MakeTestPacketPayloadFromUniqueId(
                                           unique_payload_ids++));
 
   // Build headers.

--- a/tests/sflow/sflow_util_test.cc
+++ b/tests/sflow/sflow_util_test.cc
@@ -476,21 +476,6 @@ TEST(SflowconfigTest, MoreThanTwoCollectorsFailure) {
           HasSubstr("Number of collectors exceeds max allowed value of 2")));
 }
 
-TEST(SflowconfigTest, MoreThanTwoCollectorsFailure) {
-  EXPECT_THAT(
-      UpdateSflowConfig(
-          kGnmiConfig,
-          /*agent_addr_ipv6=*/"8002:12::aab0",
-          /*collector_address_to_port=*/
-          {{"12:34:56::78", 6343}, {"34:56:78::9a", 6343}},
-          /*sflow_interfaces=*/{{"Ethernet3", true}, {"Ethernet4", true}},
-          /*sampling_rate=*/1000,
-          /*sampling_header_size=*/12),
-      StatusIs(
-          absl::StatusCode::kInvalidArgument,
-          HasSubstr("Number of collectors exceeds max allowed value of 2")));
-}
-
 TEST(SflowconfigTest, ModifyInterfaceNamesSuccess) {
   EXPECT_THAT(UpdateSflowConfig(kGnmiConfig,
                                 /*agent_addr_ipv6=*/"8002:12::aab0",


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 757 targets (20 packages loaded, 1291 targets configured).
INFO: Found 757 targets...
INFO: Elapsed time: 0.893s, Critical Path: 0.05s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 757 targets (0 packages loaded, 222 targets configured).
INFO: Found 528 targets and 229 test targets...
INFO: Elapsed time: 196.841s, Critical Path: 138.76s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.2s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.4s
//tests/sflow:sflow_util_test                                            PASSED in 7.8s
//thinkit:bazel_test_environment_test                                    PASSED in 1.6s
//thinkit:generic_testbed_test                                           PASSED in 2.3s
//thinkit:mock_control_device_test                                       PASSED in 1.7s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.2s
//tests/lib:packet_generator_test                                        PASSED in 64.3s
  Stats over 4 runs: max = 64.3s, min = 62.5s, avg = 63.4s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.7s, avg = 1.9s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.3s
  Stats over 50 runs: max = 46.3s, min = 1.3s, avg = 4.6s, dev = 10.3s

Executed 229 out of 229 tests: 229 tests pass.
