### PR TITLE
[Thinkit/Tests]  Replace MakeTestPacketPayloadFromUniqueId with MakeTestPacketTagFromUniqueId

### DIFF
--- a/tests/forwarding/acl_feature_test.cc
+++ b/tests/forwarding/acl_feature_test.cc
@@ -79,9 +79,9 @@ dvaas::PacketTestVector UdpPacket(
   ProtoFixtureRepository repo;
 
   repo.RegisterValue("@payload_ipv4",
-                     dvaas::MakeTestPacketPayloadFromUniqueId(1))
+                     dvaas::MakeTestPacketTagFromUniqueId(1, "IPv4 UDP packet"))
       .RegisterValue("@payload_ipv6",
-                     dvaas::MakeTestPacketPayloadFromUniqueId(2))
+                     dvaas::MakeTestPacketTagFromUniqueId(2, "IPv6 UDP packet"))
       .RegisterValue("@ingress_port", egress_port)
       .RegisterValue("@egress_port", egress_port)
       .RegisterValue("@ingress_dst_mac", "00:aa:bb:cc:cc:dd")

--- a/tests/forwarding/l3_multicast_test.cc
+++ b/tests/forwarding/l3_multicast_test.cc
@@ -982,8 +982,11 @@ TEST_P(L3MulticastTestFixture, ReplicatingNTimesToSamePortProducesNCopies) {
       .RegisterValue("@decremented_hop_limit", "0x4f")
       .RegisterValue("@decremented_ttl", "0x3f")
       .RegisterValue("@ipv4_dst", input_ipv4_address.ToString())
-      .RegisterValue("@payload_ipv4", dvaas::MakeTestPacketPayloadFromUniqueId(
-                                          unique_payload_ids++));
+      .RegisterValue(
+          "@payload_ipv4",
+          dvaas::MakeTestPacketTagFromUniqueId(
+              unique_payload_ids++,
+              "IPv4 multicast packet expected to hit multicast group 1"));
 
   // Build headers.
   repo.RegisterSnippetOrDie<packetlib::Header>("@ethernet_ipv4", R"pb(

--- a/tests/forwarding/tunnel_decap_test.cc
+++ b/tests/forwarding/tunnel_decap_test.cc
@@ -81,7 +81,7 @@ dvaas::PacketTestVector Ipv6InIpv6DecapTestVector(
     const TunnelDecapTestVectorParams& packet_vector_param) {
   ProtoFixtureRepository repo;
 
-  repo.RegisterValue("@payload", dvaas::MakeTestPacketPayloadFromUniqueId(
+  repo.RegisterValue("@payload", dvaas::MakeTestPacketTagFromUniqueId(
                                      1, "Testing IPv6-in-Ipv6 packets"))
       .RegisterValue("@ingress_port", packet_vector_param.in_port)
       .RegisterValue("@egress_port", packet_vector_param.out_port)
@@ -167,7 +167,7 @@ dvaas::PacketTestVector Ipv4InIpv6DecapTestVector(
     const TunnelDecapTestVectorParams& packet_vector_param) {
   ProtoFixtureRepository repo;
 
-  repo.RegisterValue("@payload", dvaas::MakeTestPacketPayloadFromUniqueId(
+  repo.RegisterValue("@payload", dvaas::MakeTestPacketTagFromUniqueId(
                                      1, "Testing IPv4-in-Ipv6 packets"))
       .RegisterValue("@ingress_port", packet_vector_param.in_port)
       .RegisterValue("@egress_port", packet_vector_param.out_port)
@@ -257,7 +257,7 @@ dvaas::PacketTestVector Ipv4InIpv6NoDecapTestVector(
     const TunnelDecapTestVectorParams &packet_vector_param) {
   ProtoFixtureRepository repo;
 
-  repo.RegisterValue("@payload", dvaas::MakeTestPacketPayloadFromUniqueId(
+  repo.RegisterValue("@payload", dvaas::MakeTestPacketTagFromUniqueId(
                                      1, "Testing IPv4-in-Ipv6 packets"))
       .RegisterValue("@ingress_port", packet_vector_param.in_port)
       .RegisterValue("@egress_port", packet_vector_param.out_port)


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 757 targets (0 packages loaded, 0 targets configured).
INFO: Found 757 targets...
INFO: Elapsed time: 23.845s, Critical Path: 23.44s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 757 targets (0 packages loaded, 222 targets configured).
INFO: Found 528 targets and 229 test targets...
INFO: Elapsed time: 207.021s, Critical Path: 149.44s
INFO: 286 processes: 340 linux-sandbox, 18 local.
INFO: Build completed successfully, 286 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 1.8s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.4s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.9s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.4s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.1s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.8s
//tests/lib:packet_generator_test                                        PASSED in 64.0s
  Stats over 4 runs: max = 64.0s, min = 62.3s, avg = 63.0s, dev = 0.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.3s
  Stats over 5 runs: max = 2.3s, min = 1.6s, avg = 1.9s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.4s
  Stats over 50 runs: max = 45.4s, min = 1.4s, avg = 5.1s, dev = 10.2s

Executed 229 out of 229 tests: 229 tests pass.
