### PR TITLE
[lib] Add LACP constants and support float frame rates.

### DIFF
--- a/lib/BUILD.bazel
+++ b/lib/BUILD.bazel
@@ -179,3 +179,8 @@ cc_proto_library(
     name = "ixia_helper_cc_proto",
     deps = [":ixia_helper_proto"],
 )
+
+cc_library(
+    name = "lacp_ixia_helper",
+    hdrs = ["lacp_ixia_helper.h"],
+)

--- a/lib/ixia_helper.h
+++ b/lib/ixia_helper.h
@@ -36,6 +36,11 @@
 
 namespace pins_test::ixia {
 
+inline constexpr int kEthernetStackIndex = 1;
+
+inline constexpr std::string_view kEthernetWithoutFcsName =
+    "Ethernet II without FCS";
+
 // An Ixia port is defined by IP address of chassis, card number and
 // port number.
 // This structure holds these attributes which define an Ixia port.
@@ -164,7 +169,7 @@ absl::Status StopTraffic(absl::Span<const std::string> trefs,
 
 // SetFrameRate - sets the frame rate for the traffic to be generated
 // Takes in the tref returned by IxiaSession
-absl::Status SetFrameRate(absl::string_view tref, int64_t fps,
+absl::Status SetFrameRate(absl::string_view tref, float fps,
                           thinkit::GenericTestbed &generic_testbed);
 
 // SetLineRate - sets the line rate as 1-100 percent of max line rate
@@ -250,6 +255,10 @@ absl::Status SetIpPriority(absl::string_view tref, int dscp, int ecn_bits,
 // Takes in the tref returned by SetUpTrafficItem.
 absl::Status SetIpTTL(absl::string_view tref, int ttl, bool is_ipv4,
                       thinkit::GenericTestbed &generic_testbed);
+
+// Removes the protocol at the given index.
+absl::Status RemoveProtocolAtIndex(absl::string_view tref, int index,
+                                   thinkit::GenericTestbed &generic_testbed);
 
 // AppendTcp - Append TCP template to IP header.
 // Takes in the tref returned by SetUpTrafficItem.

--- a/lib/lacp_ixia_helper.h
+++ b/lib/lacp_ixia_helper.h
@@ -1,0 +1,64 @@
+#ifndef PINS_LIB_LACP_IXIA_HELPER_H_
+#define PINS_LIB_LACP_IXIA_HELPER_H_
+
+#include <string_view>
+
+namespace pins_test::ixia {
+
+inline constexpr std::string_view kLacpHeaderName = "LACP";
+
+// LACP should be the second header in the stack after Ethernet.
+inline constexpr int kLacpStackIndex = 2;
+
+inline constexpr std::string_view kLacpDestinationMac = "01:80:c2:00:00:02";
+
+// LACP field indices from the Ixia REST API:
+namespace LacpField {
+
+inline constexpr int kSubType = 1;
+inline constexpr int kVersion = 2;
+inline constexpr int kActorTlvType = 3;
+inline constexpr int kActorTlvLength = 4;
+inline constexpr int kActorSystemPriority = 5;
+inline constexpr int kActorSystemId = 6;
+inline constexpr int kActorKey = 7;
+inline constexpr int kActorPortPriority = 8;
+inline constexpr int kActorPortId = 9;
+inline constexpr int kActorState = 10;
+// Field 11 is reserved.
+inline constexpr int kPartnerTlvType = 12;
+inline constexpr int kPartnerTlvLength = 13;
+inline constexpr int kPartnerSystemPriority = 14;
+inline constexpr int kPartnerSystemId = 15;
+inline constexpr int kPartnerKey = 16;
+inline constexpr int kPartnerPortPriority = 17;
+inline constexpr int kPartnerPortId = 18;
+inline constexpr int kPartnerState = 19;
+// Field 20 is reserved.
+inline constexpr int kCollectorTlvType = 21;
+inline constexpr int kCollectorTlvLength = 22;
+inline constexpr int kCollectorMaxDelay = 23;
+// Field 24 is reserved.
+inline constexpr int kTerminatorTlvType = 25;
+inline constexpr int kTerminatorTlvLength = 26;
+// Field 27 is reserved.
+inline constexpr int kFCS = 28;
+
+}  // namespace LacpField
+
+namespace LacpState {
+
+inline constexpr int kActivity = 1 << 0;
+inline constexpr int kTimeout = 1 << 1;
+inline constexpr int kAggregation = 1 << 2;
+inline constexpr int kSync = 1 << 3;
+inline constexpr int kCollecting = 1 << 4;
+inline constexpr int kDistributing = 1 << 5;
+inline constexpr int kDefaulted = 1 << 6;
+inline constexpr int kExpired = 1 << 7;
+
+}  // namespace LacpState
+
+}  // namespace pins_test::ixia
+
+#endif  // PINS_LIB_LACP_IXIA_HELPER_H_


### PR DESCRIPTION
### **PR Description:**
 Add LACP constants and support float frame rates.

### **Keyword Check:**
bibhuprasad@bibhuprasad87:~/sonic_build_image_2025-08-20/sonic-buildimage/src/sonic-p4rt/sonic-pins/p4_pdpi$ sh ~/keyword_check.sh .
Keyword check Passed.

### **Build Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 759 targets (0 packages loaded, 0 targets configured).
INFO: Found 759 targets...
INFO: Elapsed time: 0.472s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

### **UT Results:**
bibhuprasad@8b3c841bfe91:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 759 targets (0 packages loaded, 384 targets configured).
INFO: Found 529 targets and 230 test targets...
INFO: Elapsed time: 193.280s, Critical Path: 136.16s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.9s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.8s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.1s
//gutil:collections_test                                                 PASSED in 1.5s
//gutil:io_test                                                          PASSED in 1.5s
//gutil:proto_matchers_test                                              PASSED in 1.5s
//gutil:proto_ordering_test                                              PASSED in 1.5s
//gutil:proto_test                                                       PASSED in 1.2s
//gutil:status_matchers_test                                             PASSED in 1.3s
//gutil:test_artifact_writer_test                                        PASSED in 2.0s
//gutil:testing_test                                                     PASSED in 1.7s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.7s
//lib:ixia_helper_test                                                   PASSED in 2.9s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.7s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.6s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.7s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.4s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.5s
//lib/utils:json_test_utils_test                                         PASSED in 1.4s
//lib/utils:json_utils_test                                              PASSED in 1.6s
//lib/validator:validator_backend_test                                   PASSED in 1.6s
//lib/validator:validator_lib_test                                       PASSED in 27.3s
//p4_fuzzer:constraints_test                                             PASSED in 10.0s
//p4_fuzzer:fuzz_util_test                                               PASSED in 135.9s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 1.4s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.4s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.2s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.6s
//p4_pdpi:built_ins_test                                                 PASSED in 1.3s
//p4_pdpi:entity_keys_test                                               PASSED in 1.5s
//p4_pdpi:ir_properties_test                                             PASSED in 1.4s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.7s
//p4_pdpi:names_test                                                     PASSED in 1.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.8s
//p4_pdpi:p4info_union_test                                              PASSED in 1.4s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.5s
//p4_pdpi:references_test                                                PASSED in 1.4s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.7s
//p4_pdpi:ternary_test                                                   PASSED in 1.3s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.6s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.7s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 6.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.4s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.3s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.7s
//p4_pdpi/testing:info_test                                              PASSED in 0.4s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.7s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.3s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.3s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.3s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.4s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.1s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.8s
//p4_symbolic:z3_util_test                                               PASSED in 1.4s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.3s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.2s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.3s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.5s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.1s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.2s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 34.2s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 34.8s
//p4_symbolic/sai:sai_test                                               PASSED in 7.4s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.1s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.0s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.2s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.3s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.2s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.3s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.5s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.0s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 3.5s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_cpu_queue_table_event_test         PASSED in 2.5s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.0s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.0s
//p4rt_app/p4runtime:cpu_queue_translator_test                           PASSED in 1.2s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.5s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.4s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.7s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.0s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.5s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.9s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 1.8s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.3s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.8s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 1.5s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 2.0s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.2s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.9s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.9s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.8s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.0s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 0.6s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.6s
//p4rt_app/tests:api_access_test                                         PASSED in 1.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.4s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 8.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 2.7s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.1s
//p4rt_app/tests:resource_limits_test                                    PASSED in 5.5s
//p4rt_app/tests:response_path_test                                      PASSED in 5.3s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.2s
//p4rt_app/utils:table_utility_test                                      PASSED in 2.4s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.0s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.2s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.2s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 3.2s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 2.0s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 5.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 4.0s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 8.2s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.7s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.2s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.6s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.3s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.8s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.1s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.6s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.8s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.3s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.2s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 2.3s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 2.4s
//tests/lib:packet_generator_test                                        PASSED in 64.7s
  Stats over 4 runs: max = 64.7s, min = 62.3s, avg = 63.6s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.4s
  Stats over 5 runs: max = 2.4s, min = 2.1s, avg = 2.3s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.5s
  Stats over 50 runs: max = 45.5s, min = 1.3s, avg = 4.9s, dev = 10.3s

Executed 230 out of 230 tests: 230 tests pass.
