### PR TITLE
[Thinkit/Tests] Adding DoNsfRebootAndWaitForSwitchReadyOrRecover to extend the functionality of Do Nsf Reboot.

### DIFF
--- a/tests/gnoi/BUILD.bazel
+++ b/tests/gnoi/BUILD.bazel
@@ -32,6 +32,7 @@ cc_library(
         "//gutil:testing",
         "//lib/gnmi:gnmi_helper",
         "//lib/validator:validator_lib",
+        "//tests:thinkit_gnmi_interface_util",
         "//tests/integration/system/nsf:util",
         "//tests/integration/system/nsf/interfaces:testbed",
         "//thinkit:control_device",

--- a/tests/gnoi/bert_tests.cc
+++ b/tests/gnoi/bert_tests.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "absl/flags/flag.h"
 #include "absl/random/random.h"
 #include "absl/status/status.h"
@@ -39,8 +40,10 @@
 #include "diag/diag.grpc.pb.h"
 #include "diag/diag.pb.h"
 #include "glog/logging.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "grpcpp/client_context.h"
+#include "gtest/gtest.h"
 #include "gutil/status.h"
 #include "gutil/status_matchers.h"
 #include "gutil/testing.h"
@@ -51,11 +54,10 @@
 #include "system/system.pb.h"
 #include "tests/integration/system/nsf/interfaces/testbed.h"
 #include "tests/integration/system/nsf/util.h"
+#include "tests/thinkit_gnmi_interface_util.h"
 #include "thinkit/control_device.h"
 #include "thinkit/generic_testbed.h"
 #include "thinkit/switch.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 ABSL_FLAG(uint32_t, idx_seed, static_cast<uint32_t>(std::time(nullptr)),
           "Seed to randomly generate interface index.");
@@ -1250,6 +1252,15 @@ TEST_P(BertTest, StartBertSucceeds) {
       ValidatePortsUp(sut, control_device, sut_interfaces_, peer_interfaces_));
 }
 
+// Prune the interfaces that cannot allow disabling each lane independently.
+// These interfaces are not supported for BERT.
+// TODO: Add code to remove interfaces from sut_test_interfaces that are not applicable for BERT.
+absl::Status PruneUnsupportedInterfaces(
+    std::vector<std::string>& sut_test_interfaces,
+    gnmi::gNMI::StubInterface& sut_gnmi_stub) {
+  return absl::OkStatus();
+}
+
 // Runs the BERT test on current maximum allowed number of interfaces. During
 // the BERT run:
 // 1) Disable admin state of few ports on SUT,
@@ -1272,6 +1283,7 @@ TEST_P(BertTest, RunBertOnMaximumAllowedPorts) {
 
   // Get all the interfaces that are operational status "UP".
   sut_test_interfaces_ = sut_interfaces_;
+  ASSERT_OK(PruneUnsupportedInterfaces(sut_test_interfaces_, *sut_gnmi_stub_));
   // Resize the interface list if UP ports are more than max number of allowed
   // ports.
   if (sut_test_interfaces_.size() > kMaxAllowedInterfacesToRunBert) {

--- a/tests/gnoi/factory_reset_test.cc
+++ b/tests/gnoi/factory_reset_test.cc
@@ -45,7 +45,7 @@ constexpr absl::Duration kPingReachabilityInterval = absl::Seconds(2);
 constexpr absl::Duration kPingTimeout = absl::Seconds(1);
 constexpr int kConsecutivePingsRequired = 3;
 constexpr absl::Duration kFactoryResetWaitForUpTime = absl::Minutes(25);
-constexpr absl::Duration kSshSessionTimeout = absl::Seconds(5);
+constexpr absl::Duration kSshSessionTimeout = absl::Seconds(20);
 
 void IssueGnoiFactoryResetAndValidateStatus(
     thinkit::Switch& sut, const gnoi::factory_reset::StartRequest& request,

--- a/tests/integration/system/nsf/util.h
+++ b/tests/integration/system/nsf/util.h
@@ -143,7 +143,8 @@ absl::Status WaitForSwitchState(thinkit::Switch& thinkit_switch,
                                 absl::Span<const std::string> interfaces = {});
 
 // Reboot the SUT using the given reboot `method`.
-absl::Status Reboot(gnoi::system::RebootMethod method, const Testbed &testbed);
+absl::Status Reboot(gnoi::system::RebootMethod method, const Testbed& testbed,
+                    bool collect_debug_artifacts_before_reboot = true);
 
 // Performs image copy on the inactive side using gNOI, and returns the upgraded
 // image version on success.
@@ -196,6 +197,14 @@ absl::Status WaitForNsfReboot(
 absl::Status DoNsfRebootAndWaitForSwitchReady(
     const Testbed &testbed, thinkit::SSHClient &ssh_client,
     absl::Nullable<const ImageConfigParams *> image_config_param = nullptr,
+    bool check_interfaces_up = true,
+    absl::Span<const std::string> interfaces = {});
+
+// Performs an NSF reboot and waits for the SUT to be ready.In the event of an
+// NSF reboot failure, a cold reboot is executed on the switch to recover it.
+absl::Status DoNsfRebootAndWaitForSwitchReadyOrRecover(
+    const Testbed& testbed, thinkit::SSHClient& ssh_client,
+    absl::Nullable<const ImageConfigParams*> image_config_param = nullptr,
     bool check_interfaces_up = true,
     absl::Span<const std::string> interfaces = {});
 


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 762 targets (1 packages loaded, 6 targets configured).
INFO: Found 762 targets...
INFO: Elapsed time: 25.523s, Critical Path: 24.94s
INFO: 4 processes: 1 internal, 3 linux-sandbox.
INFO: Build completed successfully, 4 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 762 targets (0 packages loaded, 0 targets configured).
INFO: Found 531 targets and 231 test targets...
INFO: Elapsed time: 201.122s, Critical Path: 143.92s
INFO: 288 processes: 342 linux-sandbox, 18 local.
INFO: Build completed successfully, 288 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.2s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 2.0s
//tests/sflow:sflow_util_test                                            PASSED in 8.2s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 2.1s
//thinkit:mock_control_device_test                                       PASSED in 1.4s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.9s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.8s
//tests/lib:packet_generator_test                                        PASSED in 63.4s
  Stats over 4 runs: max = 63.4s, min = 61.4s, avg = 62.7s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.5s
  Stats over 5 runs: max = 2.5s, min = 1.7s, avg = 2.2s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.8s
  Stats over 50 runs: max = 45.8s, min = 1.2s, avg = 3.8s, dev = 8.5s

Executed 231 out of 231 tests: 231 tests pass.
