### PR TITLE
[Thinkit/Tests] Refactor TakeP4FlowSnapshot and SaveP4FlowSnapshot to take in a Switch object instead of a Testbed object.

### DIFF
--- a/tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc
+++ b/tests/integration/system/nsf/nsf_acl_flow_coverage_test.cc
@@ -47,7 +47,7 @@ void NsfAclFlowCoverageTestFixture::TearDown() {
 }
 
 TEST_P(NsfAclFlowCoverageTestFixture, NsfAclFlowCoverageTest) {
-
+  thinkit::TestEnvironment& environment = GetTestEnvironment(testbed_);
   // The test needs at least 1 image_config_param to run.
   if (GetParam().image_config_params.empty()) {
     GTEST_SKIP() << "No image config params provided";
@@ -64,12 +64,12 @@ TEST_P(NsfAclFlowCoverageTestFixture, NsfAclFlowCoverageTest) {
   // P4 snapshot before programming flows and starting the traffic.
   LOG(INFO) << "Capturing P4 snapshot before programming flows and starting "
                "the traffic";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot1,
-                       TakeP4FlowSnapshot(testbed_));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot1, TakeP4FlowSnapshot(sut));
   ASSERT_OK(SaveP4FlowSnapshot(
-      testbed_, p4flow_snapshot1,
+      p4flow_snapshot1,
       absl::StrCat(sut.ChassisName(),
-                   "p4flow_snapshot1_before_programming_flows.txt")));
+                   "p4flow_snapshot1_before_programming_flows.txt"),
+      environment));
 
   // Program all the flows.
   LOG(INFO) << "Programming L3 flows before starting the traffic";
@@ -83,22 +83,22 @@ TEST_P(NsfAclFlowCoverageTestFixture, NsfAclFlowCoverageTest) {
 
   // P4 snapshot before NSF reboot.
   LOG(INFO) << "Capturing P4 snapshot before NSF reboot";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot2,
-                       TakeP4FlowSnapshot(testbed_));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot2, TakeP4FlowSnapshot(sut));
   ASSERT_OK(SaveP4FlowSnapshot(
-      testbed_, p4flow_snapshot2,
-      absl::StrCat(sut.ChassisName(), "p4flow_snapshot2_before_nsf.txt")));
+      p4flow_snapshot2,
+      absl::StrCat(sut.ChassisName(), "p4flow_snapshot2_before_nsf.txt"),
+      environment));
 
   ASSERT_OK(DoNsfRebootAndWaitForSwitchReady(testbed_, *ssh_client_,
                                              &image_config_param));
 
   // P4 snapshot after upgrade and NSF reboot.
   LOG(INFO) << "Capturing P4 snapshot after NSF reboot";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot3,
-                       TakeP4FlowSnapshot(testbed_));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot3, TakeP4FlowSnapshot(sut));
   ASSERT_OK(SaveP4FlowSnapshot(
-      testbed_, p4flow_snapshot3,
-      absl::StrCat(sut.ChassisName(), "p4flow_snapshot3_after_nsf.txt")));
+      p4flow_snapshot3,
+      absl::StrCat(sut.ChassisName(), "p4flow_snapshot3_after_nsf.txt"),
+      environment));
 
   // Stop and validate traffic
   LOG(INFO) << "Stopping the traffic";
@@ -118,12 +118,12 @@ TEST_P(NsfAclFlowCoverageTestFixture, NsfAclFlowCoverageTest) {
 
   // P4 snapshot after cleaning up flows.
   LOG(INFO) << "Capturing P4 snapshot after cleaning up flows";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot4,
-                       TakeP4FlowSnapshot(testbed_));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot4, TakeP4FlowSnapshot(sut));
   ASSERT_OK(SaveP4FlowSnapshot(
-      testbed_, p4flow_snapshot4,
+      p4flow_snapshot4,
       absl::StrCat(sut.ChassisName(),
-                   "p4flow_snapshot4_after_clearing_flows.txt")));
+                   "p4flow_snapshot4_after_clearing_flows.txt"),
+      environment));
 
   LOG(INFO) << "Comparing P4 snapshots - Before Programming Flows Vs After "
                "Clearing Flows";

--- a/tests/integration/system/nsf/nsf_concurrent_config_push_flow_programming_test.cc
+++ b/tests/integration/system/nsf/nsf_concurrent_config_push_flow_programming_test.cc
@@ -80,11 +80,10 @@ TEST_P(NsfConcurrentConfigPushFlowProgrammingTestFixture,
   // P4 snapshot before programming flows and starting the traffic.
   LOG(INFO) << "Capturing P4 snapshot before programming flows and starting "
                "the traffic";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot1,
-                       TakeP4FlowSnapshot(testbed_));
-  ASSERT_OK(
-      SaveP4FlowSnapshot(testbed_, p4flow_snapshot1,
-                         "p4flow_snapshot1_before_programming_flows.txt"));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot1, TakeP4FlowSnapshot(sut));
+  ASSERT_OK(SaveP4FlowSnapshot(p4flow_snapshot1,
+                               "p4flow_snapshot1_before_programming_flows.txt",
+                               environment));
 
   // Program all the flows.
   LOG(INFO) << "Programming L3 flows before starting the traffic";
@@ -121,15 +120,15 @@ TEST_P(NsfConcurrentConfigPushFlowProgrammingTestFixture,
       absl::UnknownError("Yet to program flows");
   ReadResponse p4flow_snapshot2;
   std::thread flow_programming_thread([&flow_programming_status, &sut,
-                                       &image_config_param, &p4flow_snapshot2,
-                                       this]() -> absl::Status {
+                                       &environment, &image_config_param,
+                                       &p4flow_snapshot2]() -> absl::Status {
     LOG(INFO) << "Programming ACL flows";
     RETURN_IF_ERROR(ProgramAclFlows(sut, image_config_param.p4_info));
     // P4 snapshot before NSF reboot.
     LOG(INFO) << "Capturing P4 snapshot before NSF reboot";
-    ASSIGN_OR_RETURN(p4flow_snapshot2, TakeP4FlowSnapshot(testbed_));
+    ASSIGN_OR_RETURN(p4flow_snapshot2, TakeP4FlowSnapshot(sut));
     flow_programming_status = SaveP4FlowSnapshot(
-        testbed_, p4flow_snapshot2, "p4flow_snapshot2_before_nsf.txt");
+        p4flow_snapshot2, "p4flow_snapshot2_before_nsf.txt", environment);
     if (flow_programming_status.ok()) {
       LOG(INFO) << "Completed programming ACL flows";
     } else {
@@ -164,10 +163,9 @@ TEST_P(NsfConcurrentConfigPushFlowProgrammingTestFixture,
 
   // P4 snapshot after upgrade and NSF reboot.
   LOG(INFO) << "Capturing P4 snapshot after NSF reboot";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot3,
-                       TakeP4FlowSnapshot(testbed_));
-  ASSERT_OK(SaveP4FlowSnapshot(testbed_, p4flow_snapshot3,
-                               "p4flow_snapshot3_after_nsf.txt"));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot3, TakeP4FlowSnapshot(sut));
+  ASSERT_OK(SaveP4FlowSnapshot(p4flow_snapshot3,
+                               "p4flow_snapshot3_after_nsf.txt", environment));
 
   // Stop and validate traffic
   LOG(INFO) << "Stopping the traffic";
@@ -185,10 +183,10 @@ TEST_P(NsfConcurrentConfigPushFlowProgrammingTestFixture,
 
   // P4 snapshot after clearing flows.
   LOG(INFO) << "Capturing P4 snapshot after clearing flows";
-  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot4,
-                       TakeP4FlowSnapshot(testbed_));
-  ASSERT_OK(SaveP4FlowSnapshot(testbed_, p4flow_snapshot4,
-                               "p4flow_snapshot4_after_clearing_flows.txt"));
+  ASSERT_OK_AND_ASSIGN(ReadResponse p4flow_snapshot4, TakeP4FlowSnapshot(sut));
+  ASSERT_OK(SaveP4FlowSnapshot(p4flow_snapshot4,
+                               "p4flow_snapshot4_after_clearing_flows.txt",
+                               environment));
 
   LOG(INFO) << "Comparing P4 snapshots - Before Programming Flows Vs After "
                "Clearing Flows";

--- a/tests/integration/system/nsf/upgrade_test.cc
+++ b/tests/integration/system/nsf/upgrade_test.cc
@@ -137,24 +137,24 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   LOG(INFO) << "Capturing P4 snapshot before programming flows and starting "
                "the traffic";
 
-  ReadResponse p4flow_snapshot1;
-  auto status_or_p4_snapshot1 = TakeP4FlowSnapshot(testbed_);
-  if (!status_or_p4_snapshot1.ok()) {
+  absl::StatusOr<ReadResponse> p4_snapshot_1 =
+      TakeP4FlowSnapshot(GetSut(testbed_));
+  if (!p4_snapshot_1.ok()) {
     AppendErrorStatus(overall_status,
                       absl::InternalError(absl::StrFormat(
                           "Failed to take P4 snapshot before programming flows "
                           "and starting traffic: %s",
-                          status_or_p4_snapshot1.status().message())));
+                          p4_snapshot_1.status().message())));
   } else {
-    p4flow_snapshot1 = status_or_p4_snapshot1.value();
     if (!SaveP4FlowSnapshot(
-             testbed_, p4flow_snapshot1,
+             *p4_snapshot_1,
              absl::StrCat(curr_image_config.image_version, "_",
                           next_image_config.image_version,
                           "_p4flow_snapshot_before_programming_flows_",
                           absl::FormatTime("%H_%M_%S", absl::Now(),
                                            absl::LocalTimeZone()),
-                          ".txt"))
+                          ".txt"),
+             GetTestEnvironment(testbed_))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot before programming flows";
     }
@@ -203,24 +203,24 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   // P4 snapshot before Upgrade and NSF reboot.
   LOG(INFO) << "Capturing P4 snapshot before Upgrade and NSF reboot";
 
-  ReadResponse p4flow_snapshot2;
-  auto status_or_p4_snapshot2 = TakeP4FlowSnapshot(testbed_);
-  if (!status_or_p4_snapshot2.ok()) {
+  absl::StatusOr<ReadResponse> p4_snapshot_2 =
+      TakeP4FlowSnapshot(GetSut(testbed_));
+  if (!p4_snapshot_2.ok()) {
     AppendErrorStatus(
         overall_status,
         absl::InternalError(absl::StrFormat(
             "Failed to take P4 snapshot before Upgrade and NSF reboot: %s",
-            status_or_p4_snapshot2.status().message())));
+            p4_snapshot_2.status().message())));
   } else {
-    p4flow_snapshot2 = status_or_p4_snapshot2.value();
     if (!SaveP4FlowSnapshot(
-             testbed_, p4flow_snapshot2,
+             *p4_snapshot_2,
              absl::StrCat(curr_image_config.image_version, "_",
                           next_image_config.image_version,
                           "_p4flow_snapshot_before_upgrade_and_nsf_reboot_",
                           absl::FormatTime("%H_%M_%S", absl::Now(),
                                            absl::LocalTimeZone()),
-                          ".txt"))
+                          ".txt"),
+             GetTestEnvironment(testbed_))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot before upgrade and NSF reboot";
     }
@@ -311,24 +311,24 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   // P4 snapshot after upgrade and NSF reboot.
   LOG(INFO) << "Capturing P4 snapshot after Upgrade and NSF reboot";
 
-  ReadResponse p4flow_snapshot3;
-  auto status_or_p4_snapshot3 = TakeP4FlowSnapshot(testbed_);
-  if (!status_or_p4_snapshot3.ok()) {
+  absl::StatusOr<ReadResponse> p4_snapshot_3 =
+      TakeP4FlowSnapshot(GetSut(testbed_));
+  if (!p4_snapshot_3.ok()) {
     AppendErrorStatus(
         overall_status,
         absl::InternalError(absl::StrFormat(
             "Failed to take P4 snapshot after Upgrade and NSF reboot: %s",
-            status_or_p4_snapshot3.status().message())));
+            p4_snapshot_3.status().message())));
   } else {
-    p4flow_snapshot3 = status_or_p4_snapshot3.value();
     if (!SaveP4FlowSnapshot(
-             testbed_, p4flow_snapshot3,
+             *p4_snapshot_3,
              absl::StrCat(curr_image_config.image_version, "_",
                           next_image_config.image_version,
                           "_p4flow_snapshot_after_upgrade_and_nsf_reboot_",
                           absl::FormatTime("%H_%M_%S", absl::Now(),
                                            absl::LocalTimeZone()),
-                          ".txt"))
+                          ".txt"),
+             GetTestEnvironment(testbed_))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot after upgrade and NSF reboot";
     }
@@ -469,34 +469,34 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
   // P4 snapshot after cleaning up flows.
   LOG(INFO) << "Capturing P4 snapshot after cleaning up flows";
 
-  ReadResponse p4flow_snapshot4;
-  auto status_or_p4_snapshot4 = TakeP4FlowSnapshot(testbed_);
-  if (!status_or_p4_snapshot4.ok()) {
+  absl::StatusOr<ReadResponse> p4_snapshot_4 =
+      TakeP4FlowSnapshot(GetSut(testbed_));
+  if (!p4_snapshot_4.ok()) {
     AppendErrorStatus(
         overall_status,
         absl::InternalError(absl::StrFormat(
             "Failed to take P4 snapshot after cleaning up flows: %s",
-            status_or_p4_snapshot4.status().message())));
+            p4_snapshot_4.status().message())));
   } else {
-    p4flow_snapshot4 = status_or_p4_snapshot4.value();
     if (!SaveP4FlowSnapshot(
-             testbed_, p4flow_snapshot4,
+             *p4_snapshot_4,
              absl::StrCat(curr_image_config.image_version, "_",
                           next_image_config.image_version,
                           "_p4flow_snapshot_after_clearing_flows_",
                           absl::FormatTime("%H_%M_%S", absl::Now(),
                                            absl::LocalTimeZone()),
-                          ".txt"))
+                          ".txt"),
+             GetTestEnvironment(testbed_))
              .ok()) {
       LOG(ERROR) << "Failed to save P4 snapshot after clearing flows";
     }
   }
 
-  if (status_or_p4_snapshot1.ok() && status_or_p4_snapshot4.ok()) {
+  if (p4_snapshot_1.ok() && p4_snapshot_4.ok()) {
     LOG(INFO) << upgrade_path
               << ": Comparing P4 snapshots - Before Programming Flows Vs After "
                  "Clearing Flows";
-    status = CompareP4FlowSnapshots(p4flow_snapshot1, p4flow_snapshot4);
+    status = CompareP4FlowSnapshots(*p4_snapshot_1, *p4_snapshot_4);
     if (!status.ok()) {
       GetTestEnvironment(testbed_)
           .StoreTestArtifact(
@@ -517,11 +517,11 @@ absl::Status NsfUpgradeTest::NsfUpgradeOrReboot(
     }
   }
 
-  if (status_or_p4_snapshot2.ok() && status_or_p4_snapshot3.ok()) {
+  if (p4_snapshot_2.ok() && p4_snapshot_3.ok()) {
     LOG(INFO) << upgrade_path
               << ": Comparing P4 snapshots - Before Upgrade + NSF Reboot Vs."
                  "After Upgrade + NSF Reboot";
-    status = CompareP4FlowSnapshots(p4flow_snapshot2, p4flow_snapshot3);
+    status = CompareP4FlowSnapshots(*p4_snapshot_2, *p4_snapshot_3);
     if (!status.ok()) {
       GetTestEnvironment(testbed_)
           .StoreTestArtifact(

--- a/tests/integration/system/nsf/util.cc
+++ b/tests/integration/system/nsf/util.cc
@@ -800,8 +800,7 @@ absl::Status ProgramAclFlows(thinkit::Switch& thinkit_switch,
   return pdpi::InstallPiEntities(sut_p4rt.get(), ir_p4info, pi_entities);
 }
 
-absl::StatusOr<ReadResponse> TakeP4FlowSnapshot(const Testbed &testbed) {
-  thinkit::Switch& sut = GetSut(testbed);
+absl::StatusOr<ReadResponse> TakeP4FlowSnapshot(thinkit::Switch& sut) {
   ReadRequest read_request;
   read_request.add_entities()->mutable_table_entry();
   read_request.add_entities()->mutable_packet_replication_engine_entry();
@@ -810,10 +809,10 @@ absl::StatusOr<ReadResponse> TakeP4FlowSnapshot(const Testbed &testbed) {
   return pdpi::SetMetadataAndSendPiReadRequest(session.get(), read_request);
 }
 
-absl::Status SaveP4FlowSnapshot(const Testbed &testbed, ReadResponse snapshot,
-                                absl::string_view file_name) {
-  return GetTestEnvironment(testbed).StoreTestArtifact(file_name,
-                                                       snapshot.DebugString());
+absl::Status SaveP4FlowSnapshot(ReadResponse snapshot,
+                                absl::string_view file_name,
+                                thinkit::TestEnvironment& env) {
+  return env.StoreTestArtifact(file_name, snapshot.DebugString());
 }
 
 absl::Status StoreSutDebugArtifacts(absl::string_view prefix,

--- a/tests/integration/system/nsf/util.h
+++ b/tests/integration/system/nsf/util.h
@@ -228,12 +228,11 @@ absl::Status PushConfig(const ImageConfigParams &image_config_param,
 absl::Status ProgramAclFlows(thinkit::Switch& thinkit_switch,
                              const p4::config::v1::P4Info& p4_info);
 
-absl::StatusOr<::p4::v1::ReadResponse>
-TakeP4FlowSnapshot(const Testbed &testbed);
+absl::StatusOr<p4::v1::ReadResponse> TakeP4FlowSnapshot(thinkit::Switch& sut);
 
-absl::Status SaveP4FlowSnapshot(const Testbed &testbed,
-                                ::p4::v1::ReadResponse snapshot,
-                                absl::string_view file_name);
+absl::Status SaveP4FlowSnapshot(p4::v1::ReadResponse snapshot,
+                                absl::string_view file_name,
+                                thinkit::TestEnvironment& env);
 
 // Stores the healthz debug artifacts of the SUT with the given `prefix` as:
 // "{prefix}_healthz"

--- a/tests/sflow/sflow_test.cc
+++ b/tests/sflow/sflow_test.cc
@@ -2540,7 +2540,7 @@ absl::Status SflowMirrorTestFixture::NsfRebootAndWaitForConvergence(
                      /*prefix=*/"pre_nsf_", testbed.Environment());
   LOG(INFO) << "Start NSF reboot on switch";
   ASSIGN_OR_RETURN(::p4::v1::ReadResponse p4flow_snapshot_before_nsf,
-                   pins_test::TakeP4FlowSnapshot(&testbed));
+                   pins_test::TakeP4FlowSnapshot(testbed.Sut()));
   pins_test::ImageConfigParams image_config_params{
       .gnmi_config = std::string(gnmi_config),
   };
@@ -2549,7 +2549,7 @@ absl::Status SflowMirrorTestFixture::NsfRebootAndWaitForConvergence(
   CollectSflowDebugs(GetParam().ssh_client, testbed.Sut().ChassisName(),
                      /*prefix=*/"post_nsf_", testbed.Environment());
   ASSIGN_OR_RETURN(::p4::v1::ReadResponse p4flow_snapshot_after_nsf,
-                   pins_test::TakeP4FlowSnapshot(&testbed));
+                   pins_test::TakeP4FlowSnapshot(testbed.Sut()));
   RETURN_IF_ERROR(pins_test::CompareP4FlowSnapshots(p4flow_snapshot_before_nsf,
                                                     p4flow_snapshot_after_nsf));
   LOG(INFO) << "NSF reboot finished and switch is converged.";


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 760 targets (0 packages loaded, 0 targets configured).
INFO: Found 760 targets...
INFO: Elapsed time: 28.638s, Critical Path: 28.23s
INFO: 18 processes: 1 internal, 17 linux-sandbox.
INFO: Build completed successfully, 18 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 760 targets (0 packages loaded, 0 targets configured).
INFO: Found 529 targets and 231 test targets...
INFO: Elapsed time: 200.533s, Critical Path: 143.08s
INFO: 288 processes: 342 linux-sandbox, 18 local.
INFO: Build completed successfully, 288 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.4s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 2.6s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.9s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//thinkit:mock_control_device_test                                       PASSED in 1.4s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.7s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.2s
//tests/lib:packet_generator_test                                        PASSED in 63.0s
  Stats over 4 runs: max = 63.0s, min = 61.5s, avg = 62.6s, dev = 0.6s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.2s
  Stats over 5 runs: max = 2.2s, min = 1.8s, avg = 2.0s, dev = 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.5s
  Stats over 50 runs: max = 45.5s, min = 1.4s, avg = 5.1s, dev = 10.3s

Executed 231 out of 231 tests: 231 tests pass.