### PR TITLE
[Comb] Entry builder modfications

### DIFF
--- a/sai_p4/instantiations/google/test_tools/test_entries.cc
+++ b/sai_p4/instantiations/google/test_tools/test_entries.cc
@@ -224,7 +224,8 @@ EntryBuilder& EntryBuilder::AddEntryAdmittingAllPacketsToL3() {
   return *this;
 }
 
-EntryBuilder& EntryBuilder::AddEntryPuntingAllPackets(PuntAction action) {
+EntryBuilder& EntryBuilder::AddEntryPuntingAllPackets(
+    PuntAction action, absl::string_view cpu_queue) {
   sai::TableEntry& entry = *entries_.add_entries();
   entry = gutil::ParseProtoOrDie<sai::TableEntry>(
       R"pb(

--- a/sai_p4/instantiations/google/test_tools/test_entries.h
+++ b/sai_p4/instantiations/google/test_tools/test_entries.h
@@ -311,7 +311,8 @@ class EntryBuilder {
 
   // Adds an entry that matches all packets and punts them according to
   // `action`.
-  EntryBuilder& AddEntryPuntingAllPackets(PuntAction action);
+  EntryBuilder& AddEntryPuntingAllPackets(PuntAction action,
+                                          absl::string_view cpu_queue = "0x7");
 
   // Constructs all entries required to forward all `ip_version` packets to
   // `egress_port` and modify them using `rewrite_options`.
@@ -421,6 +422,8 @@ class EntryBuilder {
       absl::string_view vlan_id_hexstr, absl::string_view acl_metadata_hexstr,
       const AclPreIngressVlanTableMatchFields& match_fields = {},
       int priority = 1);
+  EntryBuilder& AddEntrySettingVrfForAllPackets(absl::string_view vrf,
+                                                int priority = 1);
   EntryBuilder& AddEntrySettingVlanIdInPreIngress(
       absl::string_view vlan_id_hexstr,
       std::optional<absl::string_view> match_vlan_id_hexstr = std::nullopt,

--- a/tests/thinkit_gnmi_interface_util.cc
+++ b/tests/thinkit_gnmi_interface_util.cc
@@ -293,7 +293,7 @@ GetXcvrToInterfacesMapGivenPmdType(gnmi::gNMI::StubInterface& sut_gnmi_stub,
       continue;
     }
     std::string ethernet_pmd = transceiver_to_ethernet_pmd_type_map[xcvr_name];
-    if (absl::StrContains(ethernet_pmd, pmd_type)) {
+    if (absl::StrContains(ethernet_pmd, pmd_type)) {    
       int xcvr_num;
       if (!absl::SimpleAtoi(xcvr_name.substr(kEthernetLen), &xcvr_num)) {
         return gutil::InternalErrorBuilder().LogError()


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 758 targets (0 packages loaded, 0 targets configured).
INFO: Found 758 targets...
INFO: Elapsed time: 16.018s, Critical Path: 15.09s
INFO: 6 processes: 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 758 targets (0 packages loaded, 0 targets configured).
INFO: Found 528 targets and 230 test targets...
INFO: Elapsed time: 556.346s, Critical Path: 156.65s
INFO: 287 processes: 341 linux-sandbox, 18 local.
INFO: Build completed successfully, 287 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
/thinkit:mock_mirror_testbed_test                                       PASSED in 0.8s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 0.8s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 0.8s
//tests/lib:packet_generator_test                                        PASSED in 67.1s
  Stats over 4 runs: max = 67.1s, min = 63.1s, avg = 65.9s, dev = 1.7s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 1.1s
  Stats over 5 runs: max = 1.1s, min = 0.8s, avg = 1.0s, dev = 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 50.4s
  Stats over 50 runs: max = 50.4s, min = 1.0s, avg = 3.7s, dev = 9.6s

Executed 230 out of 230 tests: 230 tests pass.
