### PR TITLE
[Comb] Adding IsOmittable function to ir_properties_test

### DIFF
--- a/p4_pdpi/ir_properties_test.cc
+++ b/p4_pdpi/ir_properties_test.cc
@@ -23,6 +23,37 @@ namespace {
 
 using gutil::ParseProtoOrDie;
 
+TEST(IsOmittable, OmittableTypeReturnsTrue) {
+  EXPECT_FALSE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "required_field" }
+      )pb")));
+  EXPECT_FALSE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "required_field" match_type: EXACT }
+      )pb")));
+
+  EXPECT_TRUE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "omittable_field" match_type: OPTIONAL }
+      )pb")));
+
+EXPECT_TRUE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "omittable_field" match_type: TERNARY }
+      )pb")));
+
+  EXPECT_TRUE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "omittable_field" match_type: LPM }
+      )pb")));
+
+  EXPECT_TRUE(IsOmittable(ParseProtoOrDie<IrMatchFieldDefinition>(
+      R"pb(
+        match_field { id: 1 name: "omittable_field" match_type: RANGE }
+      )pb")));
+}
+
 TEST(HasP4RuntimeTranslatedType, P4RuntimeTranslatedTypeMatchFieldReturnsTrue) {
   EXPECT_FALSE(
       HasP4RuntimeTranslatedType(ParseProtoOrDie<IrMatchFieldDefinition>(

--- a/tests/thinkit_gnmi_interface_util.cc
+++ b/tests/thinkit_gnmi_interface_util.cc
@@ -293,7 +293,8 @@ GetXcvrToInterfacesMapGivenPmdType(gnmi::gNMI::StubInterface& sut_gnmi_stub,
       continue;
     }
     std::string ethernet_pmd = transceiver_to_ethernet_pmd_type_map[xcvr_name];
-    if (absl::StrContains(ethernet_pmd, pmd_type)) {
+    // Check suffix.
+    if (absl::EndsWith(ethernet_pmd, pmd_type)) {
       int xcvr_num;
       if (!absl::SimpleAtoi(xcvr_name.substr(kEthernetLen), &xcvr_num)) {
         return gutil::InternalErrorBuilder().LogError()


### PR DESCRIPTION
Keyword Check:
/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/tools/keyword_checks.sh .
Keyword check Passed.

Build Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 763 targets (4 packages loaded, 146 targets configured).
INFO: Found 763 targets...
INFO: Elapsed time: 15.777s, Critical Path: 13.92s
INFO: 6 processes: 2 internal, 4 linux-sandbox.
INFO: Build completed successfully, 6 total actions

Test Result:
/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 763 targets (0 packages loaded, 8 targets configured).
INFO: Found 531 targets and 232 test targets...
INFO: Elapsed time: 600.800s, Critical Path: 148.82s
INFO: 289 processes: 343 linux-sandbox, 18 local.
INFO: Build completed successfully, 289 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.0s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 1.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.0s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 0.9s
//thinkit:mock_ssh_client_test                                           PASSED in 0.0s
//thinkit:mock_switch_test                                               PASSED in 1.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.1s
//tests/lib:packet_generator_test                                        PASSED in 69.9s
  Stats over 4 runs: max = 69.9s, min = 60.9s, avg = 66.5s, dev = 3.4s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.4s
  Stats over 5 runs: max = 2.4s, min = 1.0s, avg = 1.3s, dev = 0.5s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 49.6s
  Stats over 50 runs: max = 49.6s, min = 1.0s, avg = 4.3s, dev = 11.5s
Executed 232 out of 232 tests: 232 tests pass.

