### PR TITLE
[P4RT]  Add explicit error for irreconcilable forwarding pipeline configs.

### DIFF
--- a/p4rt_app/sonic/app_db_manager.cc
+++ b/p4rt_app/sonic/app_db_manager.cc
@@ -340,7 +340,28 @@ absl::StatusOr<std::string> PublishExtTablesDefinitionToAppDb(
 
 }
 
-sonic::AppDbTableType GetAppDbTableType(const pdpi::IrEntity& ir_entity) {
+bool operator==(const AppDbUpdate& lhs, const AppDbUpdate& rhs) {
+  if (lhs.table != rhs.table) return false;
+  if (kfvKey(lhs.update) != kfvKey(rhs.update)) return false;
+  if (kfvOp(lhs.update) != kfvOp(rhs.update)) return false;
+  if (kfvFieldsValues(lhs.update).size() !=
+      kfvFieldsValues(rhs.update).size()) {
+    return false;
+  }
+
+  absl::flat_hash_map<std::string, std::string> lhs_values;
+  for (const auto& [field, value] : kfvFieldsValues(lhs.update)) {
+    lhs_values[field] = value;
+  }
+  for (const auto& [field, value] : kfvFieldsValues(rhs.update)) {
+    auto lhs_lookup = lhs_values.find(field);
+    if (lhs_lookup == lhs_values.end()) return false;
+    if (lhs_lookup->second != value) return false;
+  }
+  return true;
+}
+
+AppDbTableType GetAppDbTableType(const pdpi::IrEntity& ir_entity) {
   return ir_entity.table_entry().table_name() == "vrf_table"
              ? sonic::AppDbTableType::VRF_TABLE
              : sonic::AppDbTableType::P4RT;

--- a/p4rt_app/sonic/app_db_manager.h
+++ b/p4rt_app/sonic/app_db_manager.h
@@ -52,6 +52,10 @@ struct AppDbUpdate {
     return H::combine(std::move(h), update.table, kfvKey(update.update));
   }
 };
+bool operator==(const AppDbUpdate& lhs, const AppDbUpdate& rhs);
+inline bool operator!=(const AppDbUpdate& lhs, const AppDbUpdate& rhs) {
+  return !(lhs == rhs);
+}
 
 // Creates an AppDB update for the provided entity.
 absl::StatusOr<AppDbUpdate> CreateAppDbUpdate(p4::v1::Update::Type update_type,

--- a/p4rt_app/sonic/app_db_manager_test.cc
+++ b/p4rt_app/sonic/app_db_manager_test.cc
@@ -983,6 +983,140 @@ TEST_F(AppDbManagerTest, PerformAppDbUpdatesFailsOnFirstVrfTableError) {
                   HasErrorCode(kRpcAborted)));
 }
 
+TEST(AppDbUpdateTest, EqualsSelf) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+  EXPECT_TRUE(update == update);
+  EXPECT_FALSE(update != update);
+}
+
+TEST(AppDbUpdateTest, TableDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  update2.table = AppDbTableType::VRF_TABLE;
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
+TEST(AppDbUpdateTest, OpDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  kfvOp(update2.update) = DEL_COMMAND;
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
+TEST(AppDbUpdateTest, KeyDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  kfvKey(update2.update) = "update2_key";
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
+TEST(AppDbUpdateTest, FieldCountDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  kfvFieldsValues(update2.update).push_back({"field_c", "value_c"});
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
+TEST(AppDbUpdateTest, FieldDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  kfvFieldsValues(update2.update)[1].first = "field_d";
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
+TEST(AppDbUpdateTest, ValueDiffDoesNotEqual) {
+  AppDbUpdate update;
+  update.table = AppDbTableType::P4RT;
+  kfvOp(update.update) = SET_COMMAND;
+  kfvKey(update.update) = "update_key";
+  kfvFieldsValues(update.update) = {
+      {"field_a", "value_a"},
+      {"field_b", "value_b"},
+      {"field_c", "value_c"},
+  };
+
+  AppDbUpdate update2 = update;
+  kfvFieldsValues(update2.update)[1].second = "value_c";
+
+  EXPECT_FALSE(update == update2);
+  EXPECT_FALSE(update2 == update);
+  EXPECT_TRUE(update != update2);
+  EXPECT_TRUE(update2 != update);
+}
+
 }  // namespace
 }  // namespace sonic
 }  // namespace p4rt_app


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-1992:~/Oct28/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh p4rt_app/.
Keyword check Passed.

### Build & Test Results:
divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 777 targets (0 packages loaded, 0 targets configured).
INFO: Found 777 targets...
INFO: Elapsed time: 0.501s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 777 targets (0 packages loaded, 0 targets configured).
INFO: Found 541 targets and 236 test targets...
INFO: From Compiling p4rt_app/tests/forwarding_pipeline_config_test.cc:
p4rt_app/tests/forwarding_pipeline_config_test.cc:219:1: warning: 'absl::lts_20240116::StatusOr<absl::lts_20240116::flat_hash_map<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > > p4rt_app::{anonymous}::DbState(const p4rt_app::sonic::FakeSonicDbTable&)' defined but not used [-Wunused-function]
  219 | DbState(const sonic::FakeSonicDbTable& table) {
      | ^~~~~~~
p4rt_app/tests/forwarding_pipeline_config_test.cc:205:5: warning: 'int p4rt_app::{anonymous}::RemoveAnnotationFromAllActions(p4::config::v1::P4Info&, absl::lts_20240116::string_view, absl::lts_20240116::string_view)' defined but not used [-Wunused-function]
  205 | int RemoveAnnotationFromAllActions(p4::config::v1::P4Info& p4info,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
p4rt_app/tests/forwarding_pipeline_config_test.cc:149:41: warning: 'const absl::lts_20240116::flat_hash_set<std::__cxx11::basic_string<char> >& p4rt_app::{anonymous}::AliasesToKeep()' defined but not used [-Wunused-function]
  149 | const absl::flat_hash_set<std::string>& AliasesToKeep() {
      |                                         ^~~~~~~~~~~~~
INFO: Elapsed time: 198.660s, Critical Path: 139.26s
INFO: 295 processes: 348 linux-sandbox, 19 local.
INFO: Build completed successfully, 295 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_diff_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_test                                             PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 1.9s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.5s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 2.0s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil:collections_test                                                 PASSED in 1.1s
//gutil:io_test                                                          PASSED in 1.4s
//gutil:proto_matchers_test                                              PASSED in 1.5s
//gutil:proto_ordering_test                                              PASSED in 1.6s
//gutil:proto_test                                                       PASSED in 1.5s
//gutil:status_matchers_test                                             PASSED in 1.5s
//gutil:test_artifact_writer_test                                        PASSED in 1.4s
//gutil:testing_test                                                     PASSED in 1.3s
//gutil:timer_test                                                       PASSED in 5.1s
//gutil:version_test                                                     PASSED in 4.7s
//lib:basic_switch_test                                                  PASSED in 2.2s
//lib:ixia_helper_test                                                   PASSED in 2.5s
//lib:ixia_protocol_helper_test                                          PASSED in 2.5s
//lib:lacp_ixia_helper_test                                              PASSED in 2.5s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.5s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.0s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.2s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.3s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.3s
//lib/utils:json_test_utils_test                                         PASSED in 1.6s
//lib/utils:json_utils_test                                              PASSED in 1.6s
//lib/validator:validator_backend_test                                   PASSED in 1.5s
//lib/validator:validator_lib_test                                       PASSED in 27.7s
//p4_fuzzer:constraints_test                                             PASSED in 10.5s
//p4_fuzzer:fuzz_util_test                                               PASSED in 139.1s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.2s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.2s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.3s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.2s
//p4_fuzzer:switch_state_test                                            PASSED in 2.5s
//p4_pdpi:built_ins_test                                                 PASSED in 1.3s
//p4_pdpi:entity_keys_test                                               PASSED in 1.6s
//p4_pdpi:ir_properties_test                                             PASSED in 1.5s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.4s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.8s
//p4_pdpi:names_test                                                     PASSED in 1.7s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.0s
//p4_pdpi:p4info_union_test                                              PASSED in 1.9s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.1s
//p4_pdpi:references_test                                                PASSED in 1.9s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.5s
//p4_pdpi:ternary_test                                                   PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.7s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.5s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.5s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.8s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 6.9s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.3s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.4s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.1s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.8s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.1s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.9s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.2s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.5s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.6s
//p4_symbolic:z3_util_test                                               PASSED in 2.0s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.4s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.5s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.4s
//p4_symbolic/ir:cfg_test                                                PASSED in 1.5s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.0s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.2s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.2s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.0s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.2s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.2s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.6s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 36.2s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 40.0s
//p4_symbolic/sai:sai_test                                               PASSED in 9.0s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.9s
//p4_symbolic/symbolic:parser_test                                       PASSED in 2.5s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.6s
//p4_symbolic/symbolic:util_test                                         PASSED in 1.7s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.6s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.2s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.7s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 2.7s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_queue_table_event_test             PASSED in 2.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.8s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.6s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.1s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.2s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.0s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 3.2s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.8s
//p4rt_app/p4runtime:queue_translator_test                               PASSED in 1.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.4s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 1.9s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.4s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.3s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.3s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.7s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.4s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.5s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.7s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.4s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 1.7s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.4s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.3s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 10.2s
//p4rt_app/tests:front_panel_queue_name_and_id_test                      PASSED in 1.5s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.2s
//p4rt_app/tests:packetio_test                                           PASSED in 4.5s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.2s
//p4rt_app/tests:resource_limits_test                                    PASSED in 4.4s
//p4rt_app/tests:response_path_test                                      PASSED in 5.3s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 1.7s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.3s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.5s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.7s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.7s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.5s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.3s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.7s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.2s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.7s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.2s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 1.9s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.1s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.1s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 1.7s
//tests/lib:common_ir_table_entries_test                                 PASSED in 1.9s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.8s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 7.7s
//thinkit:bazel_test_environment_test                                    PASSED in 1.5s
//thinkit:generic_testbed_test                                           PASSED in 1.8s
//thinkit:mock_control_device_test                                       PASSED in 1.1s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.9s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.4s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 1.6s
//tests/lib:packet_generator_test                                        PASSED in 63.2s
  Stats over 4 runs: max = 63.2s, min = 61.9s, avg = 62.7s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.6s
  Stats over 5 runs: max = 2.6s, min = 1.9s, avg = 2.3s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.0s
  Stats over 50 runs: max = 45.0s, min = 1.2s, avg = 5.9s, dev = 11.5s

Executed 236 out of 236 tests: 236 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.