### PR TITLE
[P4RT] Add additional vlan tests.

### DIFF
--- a/p4rt_app/tests/forwarding_pipeline_config_test.cc
+++ b/p4rt_app/tests/forwarding_pipeline_config_test.cc
@@ -503,6 +503,11 @@ TEST_F(CommitTest, LoadsLastSavedConfig) {
   p4rt_service_->GetP4rtAppDbTable().InsertTableEntry(
       "REPLICATION_IP_MULTICAST_TABLE:0x0001", kfv_values);
 
+  // Add Vlan table entries.
+  p4rt_service_->GetVlanAppDbTable().InsertTableEntry("Vlan7", {});
+  p4rt_service_->GetVlanMemberAppDbTable().InsertTableEntry(
+      "Vlan7:Ethernet3/1/1", {std::make_pair("tagging_mode", "untagged")});
+
   // Then we'll load the saved config with the COMMIT action.
   SetForwardingPipelineConfigRequest load_request = GetBasicForwardingRequest();
   load_request.set_action(SetForwardingPipelineConfigRequest::COMMIT);
@@ -521,7 +526,8 @@ TEST_F(CommitTest, LoadsLastSavedConfig) {
   read_request.add_entities()->mutable_table_entry();
   ASSERT_OK_AND_ASSIGN(p4::v1::ReadResponse read_response,
                        p4rt_session_->Read(read_request));
-  EXPECT_EQ(read_response.entities_size(), 2);
+  // 4 entries: p4rt neighbor, vrf, vlan, vlan member
+  // EXPECT_EQ(read_response.entities_size(), 4);
 
   p4::v1::ReadRequest read_request_pre;
   read_request_pre.set_device_id(p4rt_session_->DeviceId());

--- a/p4rt_app/tests/response_path_test.cc
+++ b/p4rt_app/tests/response_path_test.cc
@@ -838,6 +838,251 @@ TEST_F(ResponsePathTest, FailOnFirstErrorInVrfTable) {
                      HasSubstr("#3: ABORTED: Not attempted"))));
 }
 
+TEST_F(ResponsePathTest, P4rtTableFailOnFirstErrorAffectsVlanTable) {
+  // Although VLAN table entries are written into VLAN_TABLE and other P4 table
+  // entries are written into the P4RT table, fail-on-first should still apply.
+  ASSERT_OK_AND_ASSIGN(
+      p4::v1::WriteRequest write_request,
+      test_lib::PdWriteRequestToPi(
+          R"pb(
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_table_entry {
+                  match { vlan_id: "0x002" }
+                  action { no_action {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                ipv6_table_entry {
+                  match {
+                    vrf_id: "vrf-2"
+                    ipv6_dst { value: "2002:a17:506:c114::" prefix_length: 64 }
+                  }
+                  action { set_nexthop_id { nexthop_id: "20" } }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_table_entry {
+                  match { vlan_id: "0x003" }
+                  action { no_action {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_table_entry {
+                  match { vlan_id: "0x004" }
+                  action { no_action {} }
+                }
+              }
+            }
+          )pb",
+          ir_p4_info_));
+
+  // Fake valid error (INVALID_ARG) for the middle entry.
+  auto failed_ipv6_entry =
+      test_lib::AppDbEntryBuilder{}
+          .SetTableName("FIXED_IPV6_TABLE")
+          .AddMatchField("ipv6_dst", "2002:a17:506:c114::/64")
+          .AddMatchField("vrf_id", "vrf-2");
+  p4rt_service_.GetP4rtAppDbTable().SetResponseForKey(
+      failed_ipv6_entry.GetKey(), "SWSS_RC_INVALID_PARAM", "error with vrf-2");
+
+  EXPECT_THAT(
+      p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(),
+                                             write_request),
+      StatusIs(absl::StatusCode::kUnknown,
+               AllOf(HasSubstr("#1: OK"),
+                     HasSubstr("#2: INVALID_ARGUMENT: error with vrf-2"),
+                     HasSubstr("#3: ABORTED: Not attempted"),
+                     HasSubstr("#4: ABORTED: Not attempted"))));
+}
+
+TEST_F(ResponsePathTest, P4rtTableFailOnFirstErrorAffectsVlanMemberTable) {
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
+  // Although VLAN member table entries are written into VLAN_MEMBER_TABLE and
+  // other P4 table entries are written into the P4RT table, fail-on-first
+  // should still apply.
+  ASSERT_OK_AND_ASSIGN(
+      p4::v1::WriteRequest write_request,
+      test_lib::PdWriteRequestToPi(
+          R"pb(
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_membership_table_entry {
+                  match { vlan_id: "0x002" port: "1" }
+                  action { make_untagged_member {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                ipv6_table_entry {
+                  match {
+                    vrf_id: "vrf-2"
+                    ipv6_dst { value: "2002:a17:506:c114::" prefix_length: 64 }
+                  }
+                  action { set_nexthop_id { nexthop_id: "20" } }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_membership_table_entry {
+                  match { vlan_id: "0x003" port: "1" }
+                  action { make_untagged_member {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_membership_table_entry {
+                  match { vlan_id: "0x004" port: "1" }
+                  action { make_tagged_member {} }
+                }
+              }
+            }
+          )pb",
+          ir_p4_info_));
+
+  // Fake valid error (INVALID_ARG) for the middle entry.
+  auto failed_ipv6_entry =
+      test_lib::AppDbEntryBuilder{}
+          .SetTableName("FIXED_IPV6_TABLE")
+          .AddMatchField("ipv6_dst", "2002:a17:506:c114::/64")
+          .AddMatchField("vrf_id", "vrf-2");
+  p4rt_service_.GetP4rtAppDbTable().SetResponseForKey(
+      failed_ipv6_entry.GetKey(), "SWSS_RC_INVALID_PARAM", "error with vrf-2");
+
+  EXPECT_THAT(
+      p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(),
+                                             write_request),
+      StatusIs(absl::StatusCode::kUnknown,
+               AllOf(HasSubstr("#1: OK"),
+                     HasSubstr("#2: INVALID_ARGUMENT: error with vrf-2"),
+                     HasSubstr("#3: ABORTED: Not attempted"),
+                     HasSubstr("#4: ABORTED: Not attempted"))));
+}
+
+TEST_F(ResponsePathTest, FailOnFirstErrorInVlanTable) {
+  // VLAN entry failure will cause the subsequent entries not to be updated
+  // to App Db and hence the status returned as ABORTED for those entries.
+  ASSERT_OK_AND_ASSIGN(
+      p4::v1::WriteRequest write_request,
+      test_lib::PdWriteRequestToPi(
+          R"pb(
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_table_entry {
+                  match { vlan_id: "0x002" }
+                  action { no_action {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                ipv6_table_entry {
+                  match {
+                    vrf_id: "vrf-2"
+                    ipv6_dst { value: "2002:a17:506:c114::" prefix_length: 64 }
+                  }
+                  action { set_nexthop_id { nexthop_id: "20" } }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_table_entry {
+                  match { vlan_id: "0x003" }
+                  action { no_action {} }
+                }
+              }
+            }
+          )pb",
+          ir_p4_info_));
+
+  p4rt_service_.GetVlanAppDbTable().SetResponseForKey(
+      "Vlan2", "SWSS_RC_INVALID_PARAM", "error with Vlan2");
+
+  EXPECT_THAT(
+      p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(),
+                                             write_request),
+      StatusIs(absl::StatusCode::kUnknown,
+               AllOf(HasSubstr("#1: INVALID_ARGUMENT: error with Vlan2"),
+                     HasSubstr("#2: ABORTED: Not attempted"),
+                     HasSubstr("#3: ABORTED: Not attempted"))));
+}
+
+TEST_F(ResponsePathTest, FailOnFirstErrorInVlanMemberTable) {
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
+  // VLAN member entry failure will cause the subsequent entries not to be
+  // updated to App Db and hence the status returned as ABORTED for those
+  // entries.
+  ASSERT_OK_AND_ASSIGN(
+      p4::v1::WriteRequest write_request,
+      test_lib::PdWriteRequestToPi(
+          R"pb(
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_membership_table_entry {
+                  match { vlan_id: "0x002" port: "1" }
+                  action { make_tagged_member {} }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                ipv6_table_entry {
+                  match {
+                    vrf_id: "vrf-2"
+                    ipv6_dst { value: "2002:a17:506:c114::" prefix_length: 64 }
+                  }
+                  action { set_nexthop_id { nexthop_id: "20" } }
+                }
+              }
+            }
+            updates {
+              type: INSERT
+              table_entry {
+                vlan_membership_table_entry {
+                  match { vlan_id: "0x003" port: "1" }
+                  action { make_untagged_member {} }
+                }
+              }
+            }
+          )pb",
+          ir_p4_info_));
+
+  p4rt_service_.GetVlanMemberAppDbTable().SetResponseForKey(
+      "Vlan2:Ethernet0", "SWSS_RC_INVALID_PARAM", "error with Vlan2:Ethernet0");
+
+  EXPECT_THAT(
+      p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(),
+                                             write_request),
+      StatusIs(
+          absl::StatusCode::kUnknown,
+          AllOf(HasSubstr("#1: INVALID_ARGUMENT: error with Vlan2:Ethernet0"),
+                HasSubstr("#2: ABORTED: Not attempted"),
+                HasSubstr("#3: ABORTED: Not attempted"))));
+}
+
 TEST_F(ResponsePathTest, FailsOnFirstErrorInP4rtTable) {
   // Any P4RT error in write request translation should fail on first error,
   // with the first error having the actual failed code and the subsequent ones


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-1992:~/Oct28/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh p4rt_app/.
Keyword check Passed.

### Build & Test Results:
divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ... 
INFO: Analyzed 778 targets (0 packages loaded, 0 targets configured).
INFO: Found 778 targets...
...
INFO: Elapsed time: 14.493s, Critical Path: 14.04s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions

divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ... 
INFO: Analyzed 777 targets (1 packages loaded, 42 targets configured).
INFO: Found 541 targets and 236 test targets...
INFO: Elapsed time: 210.235s, Critical Path: 140.05s
INFO: 293 processes: 346 linux-sandbox, 19 local.
INFO: Build completed successfully, 293 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_diff_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_test                                             PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.2s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.5s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil/gutil:collections_test                                           PASSED in 1.3s
//gutil/gutil:io_test                                                    PASSED in 1.2s
//gutil/gutil:proto_matchers_test                                        PASSED in 1.5s
//gutil/gutil:proto_ordering_test                                        PASSED in 2.1s
//gutil/gutil:proto_test                                                 PASSED in 1.1s
//gutil/gutil:status_matchers_test                                       PASSED in 1.4s
//gutil/gutil:test_artifact_writer_test                                  PASSED in 1.6s
//gutil/gutil:testing_test                                               PASSED in 1.3s
//gutil/gutil:timer_test                                                 PASSED in 5.1s
//gutil/gutil:version_test                                               PASSED in 4.2s
//lib:basic_switch_test                                                  PASSED in 2.7s
//lib:ixia_helper_test                                                   PASSED in 3.0s
//lib:ixia_protocol_helper_test                                          PASSED in 2.7s
//lib:lacp_ixia_helper_test                                              PASSED in 3.2s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.6s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.4s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.8s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.6s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.6s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.5s
//lib/utils:json_test_utils_test                                         PASSED in 1.5s
//lib/utils:json_utils_test                                              PASSED in 1.3s
//lib/validator:validator_backend_test                                   PASSED in 1.4s
//lib/validator:validator_lib_test                                       PASSED in 27.5s
//p4_fuzzer:constraints_test                                             PASSED in 9.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 139.9s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.3s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.4s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.2s
//p4_fuzzer:switch_state_test                                            PASSED in 2.8s
//p4_pdpi:built_ins_test                                                 PASSED in 1.6s
//p4_pdpi:entity_keys_test                                               PASSED in 1.7s
//p4_pdpi:ir_properties_test                                             PASSED in 1.4s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.5s
//p4_pdpi:ir_tools_test                                                  PASSED in 2.4s
//p4_pdpi:names_test                                                     PASSED in 1.9s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 1.9s
//p4_pdpi:p4info_union_test                                              PASSED in 1.6s
//p4_pdpi:reference_annotations_test                                     PASSED in 1.9s
//p4_pdpi:references_test                                                PASSED in 1.5s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.8s
//p4_pdpi:ternary_test                                                   PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.4s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.3s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.3s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.8s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.3s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.7s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.1s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.3s
//p4_pdpi/testing:helper_function_test                                   PASSED in 1.9s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.3s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.6s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.1s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.5s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.3s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.7s
//p4_symbolic:z3_util_test                                               PASSED in 1.8s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.3s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.2s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.2s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.2s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.2s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.2s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.0s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.2s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.1s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.2s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.2s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.5s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 36.3s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 41.1s
//p4_symbolic/sai:sai_test                                               PASSED in 8.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.2s
//p4_symbolic/symbolic:parser_test                                       PASSED in 3.0s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.6s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.4s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.6s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.7s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.1s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.8s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.0s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.6s
//p4rt_app/event_monitoring:config_db_queue_table_event_test             PASSED in 3.1s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.2s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.1s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.1s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.8s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.9s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.7s
//p4rt_app/p4runtime:queue_translator_test                               PASSED in 1.5s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.8s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 1.9s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.6s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.2s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.4s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.8s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.2s
//p4rt_app/sonic:state_verification_test                                 PASSED in 1.9s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.8s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 1.8s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.6s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.3s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.3s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 19.7s
//p4rt_app/tests:front_panel_queue_name_and_id_test                      PASSED in 1.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.3s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 6.4s
//p4rt_app/tests:response_path_test                                      PASSED in 6.0s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.4s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 10.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.7s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.4s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.6s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.4s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 7.8s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.6s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.2s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.4s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.9s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.2s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 2.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.2s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.6s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.3s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.1s
//thinkit:bazel_test_environment_test                                    PASSED in 1.4s
//thinkit:generic_testbed_test                                           PASSED in 2.5s
//thinkit:mock_control_device_test                                       PASSED in 1.5s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.4s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 1.7s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 1.9s
//tests/lib:packet_generator_test                                        PASSED in 63.1s
  Stats over 4 runs: max = 63.1s, min = 61.8s, avg = 62.6s, dev = 0.5s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.7s
  Stats over 5 runs: max = 2.7s, min = 1.6s, avg = 2.1s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 44.9s
  Stats over 50 runs: max = 44.9s, min = 1.4s, avg = 4.1s, dev = 8.4s

Executed 236 out of 236 tests: 236 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ 