### PR TITLE
[P4RT] Add multicast group fallback support.

### DIFF
--- a/p4rt_app/p4runtime/ir_translation.cc
+++ b/p4rt_app/p4runtime/ir_translation.cc
@@ -200,6 +200,11 @@ absl::Status TranslatePortInReplica(const TranslateTableEntryOptions& options,
     ASSIGN_OR_RETURN(
         *replica.mutable_port(),
         TranslatePort(options.direction, options.port_map, replica.port()));
+    for (auto& backup : *replica.mutable_backup_replicas()) {
+      ASSIGN_OR_RETURN(
+          *backup.mutable_port(),
+          TranslatePort(options.direction, options.port_map, backup.port()));
+    }
   }
   return absl::OkStatus();
 }

--- a/p4rt_app/p4runtime/ir_translation_test.cc
+++ b/p4rt_app/p4runtime/ir_translation_test.cc
@@ -1378,19 +1378,88 @@ TEST(TranslatePacketReplication, FailsIfPacketReplicationHasDuplicateReplicas) {
                    .ok());
 }
 
+TEST(TranslatePacketReplication,
+     FailsIfPacketReplicationHasDuplicateReplicasInPrimaryAndBackups) {
+  p4::v1::Entity pi_entity;
+  // This packet replication entry is invalid, due to the duplicate replica.
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 1
+            replicas {
+              port: "1"
+              instance: 0
+              backup_replicas { port: "1" instance: 0 }
+              backup_replicas { port: "2" instance: 0 }
+            }
+          }
+        }
+      )pb",
+      &pi_entity));
+
+  EXPECT_THAT(TranslatePiEntityForOrchAgent(
+                  pi_entity, GetIrP4Info(), /*translate_port_ids=*/true,
+                  /*port_translation_map=*/{}, EmptyCpuQueueTranslator(),
+                  EmptyFrontPanelQueueTranslator(),
+                  /*translate_key_only=*/false),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("A primary replica and its backup replicas "
+                                 "must have unique ports")));
+}
+
+TEST(TranslatePacketReplication,
+     FailsIfPacketReplicationHasDuplicateReplicasInBackups) {
+  p4::v1::Entity pi_entity;
+  // This packet replication entry is invalid, due to the duplicate replica.
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        packet_replication_engine_entry {
+          multicast_group_entry {
+            multicast_group_id: 1
+            replicas {
+              port: "1"
+              instance: 0
+              backup_replicas { port: "2" instance: 0 }
+              backup_replicas { port: "2" instance: 0 }
+            }
+          }
+        }
+      )pb",
+      &pi_entity));
+
+  EXPECT_THAT(
+      TranslatePiEntityForOrchAgent(
+          pi_entity, GetIrP4Info(), /*translate_port_ids=*/true,
+          /*port_translation_map=*/{}, EmptyCpuQueueTranslator(),
+          EmptyFrontPanelQueueTranslator(),
+          /*translate_key_only=*/false),
+      StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          HasSubstr(
+              "Each backup replica must have a unique (port, instance)-pair")));
+}
+
 TEST(TranslatePacketReplication, TranslatePortInReplicaToOaSuccess) {
   pdpi::IrPacketReplicationEngineEntry entry;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(
         multicast_group_entry {
           multicast_group_id: 1
-          replicas { port: "1" instance: 0 }
+          replicas {
+            port: "1"
+            instance: 0
+            backup_replicas { port: "2" instance: 0 }
+            backup_replicas { port: "3" instance: 0 }
+          }
         }
       )pb",
       &entry));
 
   boost::bimap<std::string, std::string> port_translation_map;
   port_translation_map.insert({"Ethernet0", "1"});
+  port_translation_map.insert({"Ethernet1", "2"});
+  port_translation_map.insert({"Ethernet2", "3"});
   TranslateTableEntryOptions options = {
       .direction = TranslationDirection::kForOrchAgent,
       .ir_p4_info = GetIrP4Info(),
@@ -1402,6 +1471,14 @@ TEST(TranslatePacketReplication, TranslatePortInReplicaToOaSuccess) {
   pdpi::IrPacketReplicationEngineEntry updated = entry;
   updated.mutable_multicast_group_entry()->mutable_replicas(0)->set_port(
       "Ethernet0");
+  updated.mutable_multicast_group_entry()
+      ->mutable_replicas(0)
+      ->mutable_backup_replicas(0)
+      ->set_port("Ethernet1");
+  updated.mutable_multicast_group_entry()
+      ->mutable_replicas(0)
+      ->mutable_backup_replicas(1)
+      ->set_port("Ethernet2");
 
   EXPECT_OK(TranslatePacketReplicationEntry(options, entry));
   EXPECT_THAT(updated, EqualsProto(entry));
@@ -1413,8 +1490,17 @@ TEST(TranslatePacketReplication, TranslatePortInReplicaToControllerSuccess) {
       R"pb(
         multicast_group_entry {
           multicast_group_id: 1
-          replicas { port: "Ethernet0" instance: 0 }
-          replicas { port: "Ethernet1" instance: 0 }
+          replicas {
+            port: "Ethernet0"
+            instance: 0
+            backup_replicas { port: "Ethernet2" instance: 0 }
+            backup_replicas { port: "Ethernet3" instance: 0 }
+          }
+          replicas {
+            port: "Ethernet1"
+            instance: 0
+            backup_replicas { port: "Ethernet4" instance: 0 }
+          }
         }
       )pb",
       &entry));
@@ -1422,6 +1508,9 @@ TEST(TranslatePacketReplication, TranslatePortInReplicaToControllerSuccess) {
   boost::bimap<std::string, std::string> port_translation_map;
   port_translation_map.insert({"Ethernet0", "1"});
   port_translation_map.insert({"Ethernet1", "2"});
+  port_translation_map.insert({"Ethernet2", "3"});
+  port_translation_map.insert({"Ethernet3", "4"});
+  port_translation_map.insert({"Ethernet4", "5"});
   TranslateTableEntryOptions options = {
       .direction = TranslationDirection::kForController,
       .ir_p4_info = GetIrP4Info(),
@@ -1432,7 +1521,19 @@ TEST(TranslatePacketReplication, TranslatePortInReplicaToControllerSuccess) {
   };
   pdpi::IrPacketReplicationEngineEntry updated = entry;
   updated.mutable_multicast_group_entry()->mutable_replicas(0)->set_port("1");
+  updated.mutable_multicast_group_entry()
+      ->mutable_replicas(0)
+      ->mutable_backup_replicas(0)
+      ->set_port("3");
+  updated.mutable_multicast_group_entry()
+      ->mutable_replicas(0)
+      ->mutable_backup_replicas(1)
+      ->set_port("4");
   updated.mutable_multicast_group_entry()->mutable_replicas(1)->set_port("2");
+  updated.mutable_multicast_group_entry()
+      ->mutable_replicas(1)
+      ->mutable_backup_replicas(0)
+      ->set_port("5");
 
   EXPECT_OK(TranslatePacketReplicationEntry(options, entry));
   EXPECT_THAT(updated, EqualsProto(entry));
@@ -1463,6 +1564,35 @@ TEST(TranslatePacketReplication, TranslatePortInReplicaToOaMissingPort) {
               StatusIs(absl::StatusCode::kFailedPrecondition));
 }
 
+TEST(TranslatePacketReplication, TranslatePortInBackupReplicaToOaMissingPort) {
+  pdpi::IrPacketReplicationEngineEntry entry;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        multicast_group_entry {
+          multicast_group_id: 1
+          replicas {
+            port: "1"
+            instance: 0
+            backup_replicas { port: "2" instance: 0 }
+          }
+        }
+      )pb",
+      &entry));
+
+  boost::bimap<std::string, std::string> port_translation_map;
+  port_translation_map.insert({"Ethernet0", "1"});
+  TranslateTableEntryOptions options = {
+      .direction = TranslationDirection::kForController,
+      .ir_p4_info = GetIrP4Info(),
+      .translate_port_ids = true,
+      .port_map = port_translation_map,
+      .cpu_queue_translator = EmptyCpuQueueTranslator(),
+      .front_panel_queue_translator = EmptyFrontPanelQueueTranslator(),
+  };
+  EXPECT_THAT(TranslatePacketReplicationEntry(options, entry),
+              StatusIs(absl::StatusCode::kFailedPrecondition));
+}
+
 TEST(TranslatePacketReplication, TranslatesReplicasToOa) {
   pdpi::IrEntity entry;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
@@ -1470,8 +1600,17 @@ TEST(TranslatePacketReplication, TranslatesReplicasToOa) {
         packet_replication_engine_entry {
           multicast_group_entry {
             multicast_group_id: 7
-            replicas { port: "1" instance: 5 }
-            replicas { port: "2" instance: 6 }
+            replicas {
+              port: "1"
+              instance: 5
+              backup_replicas { port: "3" instance: 0 }
+            }
+            replicas {
+              port: "2"
+              instance: 6
+              backup_replicas { port: "4" instance: 0 }
+              backup_replicas { port: "5" instance: 0 }
+            }
           }
         }
       )pb",
@@ -1480,6 +1619,9 @@ TEST(TranslatePacketReplication, TranslatesReplicasToOa) {
   boost::bimap<std::string, std::string> port_translation_map;
   port_translation_map.insert({"Ethernet0", "1"});
   port_translation_map.insert({"Ethernet1", "2"});
+  port_translation_map.insert({"Ethernet2", "3"});
+  port_translation_map.insert({"Ethernet3", "4"});
+  port_translation_map.insert({"Ethernet4", "5"});
   auto cpu_queue_translator = EmptyCpuQueueTranslator();
   auto front_panel_queue_translator = EmptyFrontPanelQueueTranslator();
 
@@ -1495,8 +1637,23 @@ TEST(TranslatePacketReplication, TranslatesReplicasToOa) {
       ->set_port("Ethernet0");
   updated_entry.mutable_packet_replication_engine_entry()
       ->mutable_multicast_group_entry()
+      ->mutable_replicas(0)
+      ->mutable_backup_replicas(0)
+      ->set_port("Ethernet2");
+  updated_entry.mutable_packet_replication_engine_entry()
+      ->mutable_multicast_group_entry()
       ->mutable_replicas(1)
       ->set_port("Ethernet1");
+  updated_entry.mutable_packet_replication_engine_entry()
+      ->mutable_multicast_group_entry()
+      ->mutable_replicas(1)
+      ->mutable_backup_replicas(0)
+      ->set_port("Ethernet3");
+  updated_entry.mutable_packet_replication_engine_entry()
+      ->mutable_multicast_group_entry()
+      ->mutable_replicas(1)
+      ->mutable_backup_replicas(1)
+      ->set_port("Ethernet4");
   EXPECT_THAT(updated_entry, EqualsProto(entry));
 }
 

--- a/p4rt_app/sonic/BUILD.bazel
+++ b/p4rt_app/sonic/BUILD.bazel
@@ -488,6 +488,7 @@ cc_test(
         "//p4rt_app/sonic/adapters:mock_consumer_notifier_adapter",
         "//p4rt_app/sonic/adapters:mock_notification_producer_adapter",
         "//p4rt_app/sonic/adapters:mock_table_adapter",
+        "@com_github_nlohmann_json//:nlohmann_json",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/status",
         "@com_google_googleapis//google/rpc:code_cc_proto",

--- a/p4rt_app/sonic/packet_replication_entry_translation.cc
+++ b/p4rt_app/sonic/packet_replication_entry_translation.cc
@@ -15,6 +15,7 @@
 #include "p4rt_app/sonic/packet_replication_entry_translation.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <string>
@@ -24,6 +25,7 @@
 #include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
 #include "absl/log/log.h"
+#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/match.h"
 #include "absl/strings/numbers.h"
@@ -67,20 +69,36 @@ std::string GetRedisPacketReplicationTableKey(
 std::vector<swss::FieldValueTuple> CreateFieldValues(
     const pdpi::IrPacketReplicationEngineEntry& entry) {
   nlohmann::json json_array = nlohmann::json::array();
+  nlohmann::json backups_json_array = nlohmann::json::array();
+  int backup_replica_count = 0;
   for (auto& replica : entry.multicast_group_entry().replicas()) {
     nlohmann::json json;
     json["multicast_replica_port"] = replica.port();
     json["multicast_replica_instance"] =
         absl::StrCat("0x", absl::Hex(replica.instance(), absl::kZeroPad4));
     json_array.push_back(json);
+    nlohmann::json backup_json_array = nlohmann::json::array();
+    for (auto& backup_replica : replica.backup_replicas()) {
+      nlohmann::json backup_json;
+      backup_json["multicast_replica_port"] = backup_replica.port();
+      backup_json["multicast_replica_instance"] = absl::StrCat(
+          "0x", absl::Hex(backup_replica.instance(), absl::kZeroPad4));
+      backup_json_array.push_back(backup_json);
+      ++backup_replica_count;
+    }
+    backups_json_array.push_back(backup_json_array);
   }
 
-  if (!entry.multicast_group_entry().metadata().empty()) {
-    return {{"replicas", json_array.dump()},
-            {"controller_metadata", entry.multicast_group_entry().metadata()}};
-  } else {
-    return {{"replicas", json_array.dump()}};
+  std::vector<swss::FieldValueTuple> values;
+  values.push_back({"replicas", json_array.dump()});
+  if (backup_replica_count > 0) {
+    values.push_back({"backups", backups_json_array.dump()});
   }
+  if (!entry.multicast_group_entry().metadata().empty()) {
+    values.push_back(
+        {"controller_metadata", entry.multicast_group_entry().metadata()});
+  }
+  return values;
 }
 
 void ComparePacketReplicationEntities(const pdpi::IrEntity& entity_app_db,
@@ -175,6 +193,46 @@ std::vector<std::string> GetAllPacketReplicationTableEntryKeys(
   return pre_keys;
 }
 
+absl::StatusOr<nlohmann::json> ParseJson(absl::string_view json_string) {
+  nlohmann::json json;
+#ifdef __EXCEPTIONS
+  try {
+#endif
+    json = nlohmann::json::parse(json_string);
+#ifdef __EXCEPTIONS
+  } catch (...) {
+    return gutil::InternalErrorBuilder()
+           << "Could not parse JSON string: " << json_string;
+  }
+#endif
+  return json;
+}
+
+absl::Status ParseJsonReplica(const nlohmann::json& json_replica,
+                              std::string& port_name, uint32_t& instance) {
+  if (json_replica.find("multicast_replica_port") != json_replica.end()) {
+    port_name = json_replica.at("multicast_replica_port").get<std::string>();
+  } else {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "JSON replica is missing multicast_replica_port: "
+           << json_replica;
+  }
+  if (json_replica.find("multicast_replica_instance") != json_replica.end()) {
+    std::string inst =
+        json_replica.at("multicast_replica_instance").get<std::string>();
+    if (!absl::SimpleHexAtoi(inst, &instance)) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Failed to parse multicast_replica_instance in JSON replica "
+             << json_replica;
+    }
+  } else {
+    return gutil::InvalidArgumentErrorBuilder()
+           << "JSON replica is missing multicast_replica_instance: "
+           << json_replica;
+  }
+  return absl::OkStatus();
+}
+
 absl::StatusOr<std::vector<pdpi::IrPacketReplicationEngineEntry>>
 GetAllAppDbPacketReplicationTableEntries(P4rtTable& p4rt_table) {
   std::vector<pdpi::IrPacketReplicationEngineEntry> pre_entries;
@@ -199,57 +257,51 @@ GetAllAppDbPacketReplicationTableEntries(P4rtTable& p4rt_table) {
     }
 
     // Build replicas.
+    std::vector<std::vector<pdpi::IrBackupReplica>> backup_replicas;
     for (const auto& [field, data] : p4rt_table.app_db->get(key)) {
       if (field == "replicas") {
-        nlohmann::json json;
-#ifdef __EXCEPTIONS
-        try {
-#endif
-          json = nlohmann::json::parse(data);
-#ifdef __EXCEPTIONS
-        } catch (...) {
-          return gutil::InternalErrorBuilder()
-                 << "Could not parse JSON string: " << data;
-        }
-#endif
+        ASSIGN_OR_RETURN(nlohmann::json json, ParseJson(data));
 
         for (const auto& json_replica : json) {
           std::string port_name;
           uint32_t instance;
-          if (json_replica.find("multicast_replica_port") !=
-              json_replica.end()) {
-            port_name =
-                json_replica.at("multicast_replica_port").get<std::string>();
-          } else {
-            return gutil::InvalidArgumentErrorBuilder()
-                   << "JSON replica for multicast group ID "
-                   << absl::StrCat("0x", absl::Hex(group_id))
-                   << " is missing multicast_replica_port: " << json_replica;
-          }
-          if (json_replica.find("multicast_replica_instance") !=
-              json_replica.end()) {
-            std::string inst = json_replica.at("multicast_replica_instance")
-                                   .get<std::string>();
-            if (!absl::SimpleHexAtoi(inst, &instance)) {
-              return gutil::InvalidArgumentErrorBuilder()
-                     << "Failed to parse multicast_replica_instance in "
-                     << "multicast group ID "
-                     << absl::StrCat("0x", absl::Hex(group_id))
-                     << " from JSON replica " << json_replica;
-            }
-          } else {
-            return gutil::InvalidArgumentErrorBuilder()
-                   << "JSON replica for multicast group ID "
-                   << absl::StrCat("0x", absl::Hex(group_id))
-                   << " is missing multicast_replica_instance: "
-                   << json_replica;
-          }
+          RETURN_IF_ERROR(ParseJsonReplica(json_replica, port_name, instance));
           auto* replica = multicast_group_entry->add_replicas();
           replica->set_port(port_name);
           replica->set_instance(instance);
         }
+      } else if (field == "backups") {
+        ASSIGN_OR_RETURN(nlohmann::json json, ParseJson(data));
+
+        for (const auto& json_replica : json) {
+          std::vector<pdpi::IrBackupReplica> backups;
+          for (const auto& json_backup_replica : json_replica) {
+            std::string port_name;
+            uint32_t instance;
+            RETURN_IF_ERROR(
+                ParseJsonReplica(json_backup_replica, port_name, instance));
+            pdpi::IrBackupReplica backup_replica;
+            backup_replica.set_port(port_name);
+            backup_replica.set_instance(instance);
+            backups.push_back(backup_replica);
+          }
+          backup_replicas.push_back(backups);
+        }
       } else if (field == "controller_metadata") {
         multicast_group_entry->set_metadata(data);
+      }
+    }
+    if (!backup_replicas.empty() &&
+        multicast_group_entry->replicas_size() != backup_replicas.size()) {
+      return gutil::InvalidArgumentErrorBuilder()
+             << "Backup replicas size " << backup_replicas.size()
+             << " does not match replica size "
+             << multicast_group_entry->replicas_size();
+    }
+    for (size_t i = 0; i < backup_replicas.size(); ++i) {
+      for (const auto& backup_replica : backup_replicas[i]) {
+        *multicast_group_entry->mutable_replicas(i)->add_backup_replicas() =
+            backup_replica;
       }
     }
     pre_entries.push_back(pre_entry);

--- a/p4rt_app/tests/packet_replication_table_test.cc
+++ b/p4rt_app/tests/packet_replication_table_test.cc
@@ -47,6 +47,11 @@ class PacketReplicationTableTest
 TEST_F(PacketReplicationTableTest, InsertReadAndDeleteEntry) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
 
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
@@ -57,8 +62,19 @@ TEST_F(PacketReplicationTableTest, InsertReadAndDeleteEntry) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -100,6 +116,11 @@ TEST_F(PacketReplicationTableTest, InsertReadAndDeleteEntry) {
 TEST_F(PacketReplicationTableTest, CannotInsertDuplicateEntries) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -109,8 +130,19 @@ TEST_F(PacketReplicationTableTest, CannotInsertDuplicateEntries) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -127,6 +159,11 @@ TEST_F(PacketReplicationTableTest, CannotInsertDuplicateEntries) {
 TEST_F(PacketReplicationTableTest, InsertRequestFails) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -136,8 +173,19 @@ TEST_F(PacketReplicationTableTest, InsertRequestFails) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 17
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -167,6 +215,11 @@ TEST_F(PacketReplicationTableTest, InsertRequestFails) {
 TEST_F(PacketReplicationTableTest, CannotDeleteMissingEntry) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -176,8 +229,19 @@ TEST_F(PacketReplicationTableTest, CannotDeleteMissingEntry) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -191,6 +255,11 @@ TEST_F(PacketReplicationTableTest, CannotDeleteMissingEntry) {
 TEST_F(PacketReplicationTableTest, DeleteRequestFails) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -200,8 +269,19 @@ TEST_F(PacketReplicationTableTest, DeleteRequestFails) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -238,6 +318,10 @@ TEST_F(PacketReplicationTableTest, ModifySuccess) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -247,8 +331,19 @@ TEST_F(PacketReplicationTableTest, ModifySuccess) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -284,8 +379,18 @@ TEST_F(PacketReplicationTableTest, ModifySuccess) {
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                      replicas { port: "3" instance: 1 }
                                    }
                                  }
@@ -393,6 +498,11 @@ TEST_F(PacketReplicationTableTest,
        UnsetPacketReplicationEntryTypeReturnsMulticastGroupEntry) {
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
   ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet1", "2"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet2", "3"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet3", "4"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet4", "5"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet5", "6"));
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet6", "7"));
   ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
                        test_lib::IrWriteRequestToPi(
                            R"pb(
@@ -402,8 +512,19 @@ TEST_F(PacketReplicationTableTest,
                                  packet_replication_engine_entry {
                                    multicast_group_entry {
                                      multicast_group_id: 1
-                                     replicas { port: "1" instance: 0 }
-                                     replicas { port: "2" instance: 0 }
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                       backup_replicas { port: "4" instance: 0 }
+                                     }
+                                     replicas {
+                                       port: "2"
+                                       instance: 0
+                                       backup_replicas { port: "5" instance: 0 }
+                                       backup_replicas { port: "6" instance: 0 }
+                                       backup_replicas { port: "7" instance: 0 }
+                                     }
                                    }
                                  }
                                }
@@ -446,6 +567,33 @@ TEST_F(PacketReplicationTableTest, CannotTranslatePortFailure) {
   EXPECT_THAT(
       p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(),
                                                    request),
+      StatusIs(absl::StatusCode::kUnknown, HasSubstr("Cannot translate port")));
+}
+
+TEST_F(PacketReplicationTableTest, CannotTranslateBackupPortFailure) {
+  ASSERT_OK(p4rt_service_.GetP4rtServer().AddPortTranslation("Ethernet0", "1"));
+  ASSERT_OK_AND_ASSIGN(p4::v1::WriteRequest request,
+                       test_lib::IrWriteRequestToPi(
+                           R"pb(
+                             updates {
+                               type: INSERT
+                               entity {
+                                 packet_replication_engine_entry {
+                                   multicast_group_entry {
+                                     multicast_group_id: 1
+                                     replicas {
+                                       port: "1"
+                                       instance: 0
+                                       backup_replicas { port: "3" instance: 0 }
+                                     }
+                                   }
+                                 }
+                               }
+                             })pb",
+                           ir_p4_info_));
+  // Expect port translation failure.
+  EXPECT_THAT(
+      p4_runtime::SetMetadataAndSendPiWriteRequest(p4rt_session_.get(), request),
       StatusIs(absl::StatusCode::kUnknown, HasSubstr("Cannot translate port")));
 }
 


### PR DESCRIPTION
### Keyword Check:
divyagayathris@divyagayathris-1992:~/Oct28/sonic-buildimage/src/sonic-p4rt/sonic-pins$ ~/keyword_check.sh p4rt_app/.
Keyword check Passed.

### Build & Test Results:
divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ... 
INFO: Analyzed 778 targets (0 packages loaded, 0 targets configured).
INFO: Found 778 targets...
INFO: Elapsed time: 0.381s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

divyagayathris@7c1768a7b4f1:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ... 
INFO: Analyzed 778 targets (0 packages loaded, 45 targets configured).
INFO: Found 541 targets and 237 test targets...
INFO: Elapsed time: 221.523s, Critical Path: 147.24s
INFO: 294 processes: 346 linux-sandbox, 20 local.
INFO: Build completed successfully, 294 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.1s
//dvaas:dataplane_validation_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_diff_test                                        PASSED in 0.1s
//dvaas:dvaas_detective_test                                             PASSED in 0.1s
//dvaas:port_id_map_test                                                 PASSED in 2.5s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.1s
//dvaas:test_run_validation_test                                         PASSED in 2.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.1s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 1.8s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.3s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//gutil/gutil:collections_test                                           PASSED in 1.8s
//gutil/gutil:io_test                                                    PASSED in 1.3s
//gutil/gutil:proto_matchers_test                                        PASSED in 1.1s
//gutil/gutil:proto_ordering_test                                        PASSED in 1.7s
//gutil/gutil:proto_test                                                 PASSED in 1.6s
//gutil/gutil:status_matchers_test                                       PASSED in 1.7s
//gutil/gutil:test_artifact_writer_test                                  PASSED in 2.0s
//gutil/gutil:testing_test                                               PASSED in 1.6s
//gutil/gutil:timer_test                                                 PASSED in 5.1s
//gutil/gutil:version_test                                               PASSED in 4.6s
//lib:basic_switch_test                                                  PASSED in 2.1s
//lib:ixia_helper_test                                                   PASSED in 2.9s
//lib:ixia_protocol_helper_test                                          PASSED in 3.0s
//lib:lacp_ixia_helper_test                                              PASSED in 3.1s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.7s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 16.8s
//lib/gnmi:gnmi_helper_test                                              PASSED in 4.9s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.9s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.7s
//lib/utils:json_test_utils_test                                         PASSED in 1.3s
//lib/utils:json_utils_test                                              PASSED in 1.7s
//lib/validator:validator_backend_test                                   PASSED in 1.3s
//lib/validator:validator_lib_test                                       PASSED in 27.7s
//p4_fuzzer:constraints_test                                             PASSED in 10.4s
//p4_fuzzer:fuzz_util_test                                               PASSED in 147.1s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.6s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.3s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.0s
//p4_fuzzer:switch_state_test                                            PASSED in 2.4s
//p4_pdpi:built_ins_test                                                 PASSED in 1.3s
//p4_pdpi:entity_keys_test                                               PASSED in 1.8s
//p4_pdpi:ir_properties_test                                             PASSED in 1.6s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.6s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.9s
//p4_pdpi:names_test                                                     PASSED in 2.1s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.0s
//p4_pdpi:p4info_union_test                                              PASSED in 1.3s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.2s
//p4_pdpi:references_test                                                PASSED in 1.6s
//p4_pdpi:sequencing_util_test                                           PASSED in 1.9s
//p4_pdpi:ternary_test                                                   PASSED in 1.7s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.3s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.4s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.1s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 21.6s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.7s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.2s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.1s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 7.1s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.2s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.4s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.1s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.0s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.1s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.0s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.6s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.0s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.0s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.8s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.2s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.2s
//p4_pdpi/testing:references_test                                        PASSED in 0.2s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.2s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.2s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.2s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.1s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 0.1s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 2.6s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.3s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.6s
//p4_symbolic:z3_util_test                                               PASSED in 1.9s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.0s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.0s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.2s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.3s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.4s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.3s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.3s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.1s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.2s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.0s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.1s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.1s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.2s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.1s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.7s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 36.1s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 41.0s
//p4_symbolic/sai:sai_test                                               PASSED in 9.0s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.1s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 4.3s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.9s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.1s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.5s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.2s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.8s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 21.1s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 2.8s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.7s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 2.9s
//p4rt_app/event_monitoring:config_db_queue_table_event_test             PASSED in 2.9s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.7s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 2.8s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.2s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.5s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.6s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 2.7s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 2.8s
//p4rt_app/p4runtime:queue_translator_test                               PASSED in 1.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.6s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 1.9s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.4s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.8s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.8s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.2s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 1.5s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.1s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.2s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.4s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.1s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.1s
//p4rt_app/tests:action_set_test                                         PASSED in 1.5s
//p4rt_app/tests:api_access_test                                         PASSED in 1.2s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.4s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.5s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.5s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.4s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 19.8s
//p4rt_app/tests:front_panel_queue_name_and_id_test                      PASSED in 1.6s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.6s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.1s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.4s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.5s
//p4rt_app/tests:packetio_test                                           PASSED in 4.6s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.3s
//p4rt_app/tests:resource_limits_test                                    PASSED in 6.1s
//p4rt_app/tests:response_path_test                                      PASSED in 6.1s
//p4rt_app/tests:role_test                                               PASSED in 1.6s
//p4rt_app/tests:state_verification_test                                 PASSED in 2.9s
//p4rt_app/tests:vlan_tables_test                                        PASSED in 3.8s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.1s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 10.3s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.5s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.1s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 1.8s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 1.9s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 2.9s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.1s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 1.4s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.2s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 4.8s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.8s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 8.1s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.8s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.1s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 2.8s
//tests/forwarding:hash_statistics_util_test                             PASSED in 2.4s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 1.6s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.3s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 2.7s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.2s
//tests/sflow:sflow_util_test                                            PASSED in 8.3s
//thinkit:bazel_test_environment_test                                    PASSED in 1.6s
//thinkit:generic_testbed_test                                           PASSED in 2.3s
//thinkit:mock_control_device_test                                       PASSED in 1.6s
//thinkit:mock_generic_testbed_test                                      PASSED in 2.0s
//thinkit:mock_mirror_testbed_test                                       PASSED in 1.7s
//thinkit:mock_ssh_client_test                                           PASSED in 0.1s
//thinkit:mock_switch_test                                               PASSED in 2.0s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.1s
//tests/lib:packet_generator_test                                        PASSED in 63.0s
  Stats over 4 runs: max = 63.0s, min = 61.0s, avg = 61.8s, dev = 0.8s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.3s
  Stats over 5 runs: max = 2.3s, min = 1.6s, avg = 2.0s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.2s
  Stats over 50 runs: max = 45.2s, min = 1.3s, avg = 7.5s, dev = 13.9s

Executed 237 out of 237 tests: 237 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.