### PR TITLE
[Thinkit/Tests] Changes to support arbitration test

### DIFF
--- a/lib/gnmi/BUILD.bazel
+++ b/lib/gnmi/BUILD.bazel
@@ -53,6 +53,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
+        "@com_google_absl//absl/flags:parse",
         "@com_google_protobuf//:protobuf",
         "@com_googlesource_code_re2//:re2",
         "@com_jsoncpp//:json",

--- a/sai_p4/instantiations/google/acl_ingress.p4
+++ b/sai_p4/instantiations/google/acl_ingress.p4
@@ -129,6 +129,8 @@ control acl_ingress(in headers_t headers,
   @id(ACL_INGRESS_SET_QOS_QUEUE_AND_CANCEL_COPY_ABOVE_RATE_LIMIT_ACTION_ID)
   @sai_action(SAI_PACKET_ACTION_FORWARD, SAI_PACKET_COLOR_GREEN)
   @sai_action(SAI_PACKET_ACTION_COPY_CANCEL, SAI_PACKET_COLOR_RED)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
   // TODO: Rename qos queue to cpu queue, as per action below.
   action set_qos_queue_and_cancel_copy_above_rate_limit(
       @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t qos_queue) {
@@ -142,6 +144,8 @@ control acl_ingress(in headers_t headers,
 
   @id(ACL_INGRESS_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID)
   @sai_action(SAI_PACKET_ACTION_COPY_CANCEL)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
   action set_cpu_queue_and_cancel_copy(
       @id(1) @sai_action_param(QOS_QUEUE) cpu_queue_t cpu_queue) {
     cancel_copy = true;
@@ -212,6 +216,8 @@ control acl_ingress(in headers_t headers,
   // Drops the packet at the end of the the pipeline and ensures that it is not
   // copied to the CPU. See `acl_drop` for more information on the mechanism of
   // the drop.
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
   @id(ACL_INGRESS_DENY_ACTION_ID)
   @sai_action(SAI_PACKET_ACTION_DENY)
   action acl_deny() {
@@ -262,6 +268,8 @@ control acl_ingress(in headers_t headers,
   // TODO: Remove unsupported from ToR when we order ACL
   // insert/deletes during reconcile.
 #endif
+  @unsupported
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
   action append_ingress_and_egress_timestamp(
     @sai_action_param(SAI_ACL_ENTRY_ATTR_ACTION_INSERT_INGRESS_TIMESTAMP)
     bit<8> append_ingress_timestamp,
@@ -592,6 +600,8 @@ control acl_ingress(in headers_t headers,
 
   @id(ACL_INGRESS_REDIRECT_TO_IPMC_GROUP_AND_SET_CPU_QUEUE_AND_CANCEL_COPY_ACTION_ID)
   @sai_action(SAI_PACKET_ACTION_COPY_CANCEL)
+  // TODO(PINS): unsupported to be removed when P4Orch support is added
+  @unsupported
   @action_restriction("
     // Disallow 0 since it encodes 'no multicast' in V1Model.
     multicast_group_id != 0;
@@ -712,12 +722,17 @@ control acl_ingress(in headers_t headers,
         @id(5);
 
       local_metadata.vrf_id : optional
+        @unsupported
         @id(8) @name("vrf_id")
-        @refers_to(vrf_table, vrf_id)
+        // TODO(PINS): refers is not supported for optional fields. Use
+        // if the type is changed later
+        //@refers_to(vrf_table, vrf_id)
         @sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID);
 #if defined(IP_MULTICAST_CAPABLE)
       local_metadata.route_hit : optional
         @id(9) @name("route_hit")
+        // TODO(PINS): unsupported to be removed when P4Orch support is added
+        @unsupported
         @sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT);
 #endif
     }

--- a/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
+++ b/sai_p4/instantiations/google/fabric_border_router.p4info.pb.txt
@@ -1617,6 +1617,7 @@ actions {
     alias: "set_qos_queue_and_cancel_copy_above_rate_limit"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN)"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL , SAI_PACKET_COLOR_RED)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -1795,6 +1796,7 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+    annotations: "@unsupported"
   }
   params {
     id: 1

--- a/sai_p4/instantiations/google/middleblock.p4info.pb.txt
+++ b/sai_p4/instantiations/google/middleblock.p4info.pb.txt
@@ -663,7 +663,7 @@ tables {
   match_fields {
     id: 8
     name: "vrf_id"
-    annotations: "@refers_to(vrf_table , vrf_id)"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID)"
     match_type: OPTIONAL
     type_name {
@@ -673,6 +673,7 @@ tables {
   match_fields {
     id: 9
     name: "route_hit"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
@@ -1466,6 +1467,7 @@ actions {
     name: "ingress.acl_ingress.set_cpu_queue_and_cancel_copy"
     alias: "set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -1481,6 +1483,7 @@ actions {
     id: 16777487
     name: "ingress.acl_ingress.acl_deny"
     alias: "acl_deny"
+    annotations: "@unsupported"
     annotations: "@sai_action(SAI_PACKET_ACTION_DENY)"
   }
 }
@@ -1523,6 +1526,7 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -1559,6 +1563,7 @@ actions {
     name: "ingress.acl_ingress.redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     alias: "redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
     annotations: "@action_restriction(\"\n    // Disallow 0 since it encodes \'no multicast\' in V1Model.\n    multicast_group_id != 0;\n  \")"
   }
   params {

--- a/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
+++ b/sai_p4/instantiations/google/test_tools/table_entry_generator.cc
@@ -469,6 +469,9 @@ const absl::flat_hash_set<std::string>& KnownUnsupportedTables() {
           // supports it.
           "vlan_table",
           "vlan_membership_table",
+          // TODO(PINS): Remove acl_ingress_qos_table once support for
+          // set_qos_queue_and_cancel_copy_above_rate_limit is added
+          "acl_ingress_qos_table",
       });
   return *kUnsupportedTables;
 }
@@ -486,7 +489,9 @@ absl::StatusOr<TableEntryGenerator> GetGenerator(
       {"acl_pre_ingress_vlan_table", AclPreIngressVlanTableGenerator},
       {"acl_pre_ingress_metadata_table", AclPreIngressMetadataTableGenerator},
       {"acl_ingress_table", AclIngressTableGenerator},
-      {"acl_ingress_qos_table", AclIngressQosTableGenerator},
+      // TODO(PINS): Enable acl_ingress_qos_table once support for
+      // set_qos_queue_and_cancel_copy_above_rate_limit is added
+      // {"acl_ingress_qos_table", AclIngressQosTableGenerator},
       {"acl_ingress_security_table", AclIngressSecurityTableGenerator},
       {"acl_ingress_counting_table", AclIngressCountingTableGenerator},
       // TODO: Enable this table when it has been removed from

--- a/sai_p4/instantiations/google/tor.p4info.pb.txt
+++ b/sai_p4/instantiations/google/tor.p4info.pb.txt
@@ -963,7 +963,7 @@ tables {
   match_fields {
     id: 8
     name: "vrf_id"
-    annotations: "@refers_to(vrf_table , vrf_id)"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID)"
     match_type: OPTIONAL
     type_name {
@@ -973,6 +973,7 @@ tables {
   match_fields {
     id: 9
     name: "route_hit"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
@@ -1805,6 +1806,7 @@ actions {
     alias: "set_qos_queue_and_cancel_copy_above_rate_limit"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN)"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL , SAI_PACKET_COLOR_RED)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -1821,6 +1823,7 @@ actions {
     name: "ingress.acl_ingress.set_cpu_queue_and_cancel_copy"
     alias: "set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -1999,6 +2002,7 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -2035,6 +2039,7 @@ actions {
     name: "ingress.acl_ingress.redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     alias: "redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
     annotations: "@action_restriction(\"\n    // Disallow 0 since it encodes \'no multicast\' in V1Model.\n    multicast_group_id != 0;\n  \")"
   }
   params {

--- a/sai_p4/instantiations/google/unioned_p4info.pb.txt
+++ b/sai_p4/instantiations/google/unioned_p4info.pb.txt
@@ -1510,7 +1510,7 @@ tables {
   match_fields {
     id: 8
     name: "vrf_id"
-    annotations: "@refers_to(vrf_table , vrf_id)"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_VRF_ID)"
     match_type: OPTIONAL
     type_name {
@@ -1520,6 +1520,7 @@ tables {
   match_fields {
     id: 9
     name: "route_hit"
+    annotations: "@unsupported"
     annotations: "@sai_field(SAI_ACL_TABLE_ATTR_FIELD_ROUTE_NPU_META_DST_HIT)"
     bitwidth: 1
     match_type: OPTIONAL
@@ -2112,6 +2113,7 @@ actions {
     alias: "set_qos_queue_and_cancel_copy_above_rate_limit"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD , SAI_PACKET_COLOR_GREEN)"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL , SAI_PACKET_COLOR_RED)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -2290,6 +2292,7 @@ actions {
     name: "ingress.acl_ingress.append_ingress_and_egress_timestamp"
     alias: "append_ingress_and_egress_timestamp"
     annotations: "@sai_action(SAI_PACKET_ACTION_FORWARD)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -2687,6 +2690,7 @@ actions {
     name: "ingress.acl_ingress.set_cpu_queue_and_cancel_copy"
     alias: "set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
   }
   params {
     id: 1
@@ -2702,6 +2706,7 @@ actions {
     id: 16777487
     name: "ingress.acl_ingress.acl_deny"
     alias: "acl_deny"
+    annotations: "@unsupported"
     annotations: "@sai_action(SAI_PACKET_ACTION_DENY)"
   }
 }
@@ -2727,6 +2732,7 @@ actions {
     name: "ingress.acl_ingress.redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     alias: "redirect_to_ipmc_group_and_set_cpu_queue_and_cancel_copy"
     annotations: "@sai_action(SAI_PACKET_ACTION_COPY_CANCEL)"
+    annotations: "@unsupported"
     annotations: "@action_restriction(\"\n    // Disallow 0 since it encodes \'no multicast\' in V1Model.\n    multicast_group_id != 0;\n  \")"
   }
   params {

--- a/tests/lib/BUILD.bazel
+++ b/tests/lib/BUILD.bazel
@@ -134,6 +134,7 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:span",
+        "@com_google_absl//absl/flags:parse",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/tests/lib/switch_test_setup_helpers.cc
+++ b/tests/lib/switch_test_setup_helpers.cc
@@ -33,6 +33,7 @@
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include "absl/types/span.h"
+#include "absl/flags/flag.h"
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 #include "gutil/gutil/collections.h"
@@ -50,6 +51,10 @@
 #include "tests/thinkit_sanity_tests.h"
 #include "thinkit/mirror_testbed.h"
 #include "thinkit/switch.h"
+
+// Flag used to skip gNMI push if set to false in the command line
+// TODO(PINS): To be removed when gNMI push config is supported
+ABSL_FLAG(bool, gnmi_push_support, true, "gNMI push config supported");
 
 namespace pins_test {
 namespace {
@@ -183,8 +188,12 @@ ConfigureSwitchAndReturnP4RuntimeSession(
   // P4RuntimeSession and clear the tables first.
   RETURN_IF_ERROR(TryClearingEntities(thinkit_switch, metadata));
 
-  if (gnmi_config.has_value()) {
-    RETURN_IF_ERROR(PushGnmiConfig(thinkit_switch, *gnmi_config));
+  // Push gNMI config only if it is supported
+  // TODO(PINS): To be removed when gNMI push config is supported
+  if (absl::GetFlag(FLAGS_gnmi_push_support)) {
+    if (gnmi_config.has_value()) {
+      RETURN_IF_ERROR(PushGnmiConfig(thinkit_switch, *gnmi_config));
+    }
   }
 
   ASSIGN_OR_RETURN(auto p4rt_session,

--- a/tests/thinkit_sanity_tests.cc
+++ b/tests/thinkit_sanity_tests.cc
@@ -30,6 +30,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "absl/flags/flag.h"
 #include "glog/logging.h"
 #include "gmock/gmock.h"
 #include "grpcpp/impl/codegen/client_context.h"
@@ -50,6 +51,10 @@
 #include "thinkit/mirror_testbed.h"
 #include "thinkit/ssh_client.h"
 #include "thinkit/switch.h"
+
+// Flag to bypass the gNMI call to get the boottime
+// TODO(PINS): To be removed when get boottime is supported
+ABSL_FLAG(bool, gnmi_boottime_support, true, "gNMI get boot time supported");
 
 namespace pins_test {
 namespace {
@@ -278,6 +283,14 @@ void TestGnmiConfigBlobSet(thinkit::Switch& sut) {
 //  Returns last boot time of SUT.
 absl::StatusOr<uint64_t> GetGnmiSystemBootTime(
     thinkit::Switch& sut, gnmi::gNMI::StubInterface* sut_gnmi_stub) {
+
+  // If gNMI does not support get boot time, use this flag to return
+  // a dummy value
+  // TODO(PINS): To be removed when get boottime is supported
+  if (!absl::GetFlag(FLAGS_gnmi_boottime_support)) {
+    return 0x01;
+  }
+
   ASSIGN_OR_RETURN(
       gnmi::GetRequest request,
       BuildGnmiGetRequest("system/state/boot-time", gnmi::GetRequest::STATE));


### PR DESCRIPTION
This PR contains the changes required in sonic-pins for the arbitration_test to pass. 

Four command line flags are added to bypass the gNMI calls that are not yet supported. 

bazel test //tests/thinkit:arbitration_test --define=absl=1 --test_strategy=standalone --test_arg=--gnmi_deviceid_support=false  --test_arg=--gnmi_push_support=false --test_arg=--gnmi_boottime_support=false --test_arg=--gnmi_get_config_support=false --test_arg=--pins_p4info_file="/data/sonic-pins/sai_p4/instantiations/google/middleblock.p4info.pb.txt"  

gnmi_deviceid_support - device id/node-id
gnmi_push_support - gnmi push
gnmi_boottime_support - get boot time
gnmi_get_config_support - gnmi get type 'CONFIG'  is supported

By default, all four flags are true. For the test to pass, all of them should be set to false. They can be gradually removed as and when each feature is supported in gNMI. 

Some of the fields/attributes in acl_ingress.p4 are not supported in p4orch at the moment. These are tagged as "@unsupported" and the p4info files regenerated.

In table_entry_generator.cc, moved acl_ingress_qos table under unsupported table.

 ### Keyword check
 
sonic-pins$ keyword_check.sh ./arbit.diff 
Keyword check Passed.

### Arbitration test 

pins_ondatra$ bazel test //tests/thinkit:arbitration_test --define=absl=1 --test_strategy=standalone --test_arg=--gnmi_deviceid_support=false --test_arg=--gnmi_push_support=false --test_arg=--gnmi_boottime_support=false --test_arg=--gnmi_get_config_support=false --test_arg=--pins_p4info_file="/data/sonic-pins/sai_p4/instantiations/google/middleblock.p4info.pb.txt"
Starting local Bazel server and connecting to it...
INFO: Analyzed target //tests/thinkit:arbitration_test (490 packages loaded, 27613 targets configured).
INFO: Found 1 test target...
Target //tests/thinkit:arbitration_test up-to-date:
  bazel-bin/tests/thinkit/arbitration_test
INFO: Elapsed time: 62.414s, Critical Path: 53.59s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
//tests/thinkit:arbitration_test  PASSED in 47.9s

Executed 1 out of 1 test: 1 test passes.

### Build and test results

sbiyer@57d205691b4a:/sonic/src/sonic-p4rt/sonic-pins$ pins_build 
Starting local Bazel server and connecting to it...
INFO: Analyzed 783 targets (283 packages loaded, 23153 targets configured).
INFO: Found 783 targets...
INFO: Elapsed time: 14.310s, Critical Path: 3.13s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action

sbiyer@57d205691b4a:/sonic/src/sonic-p4rt/sonic-pins$ pins_test  
INFO: Analyzed 783 targets (1 packages loaded, 711 targets configured).
INFO: Found 543 targets and 240 test targets...
INFO: Elapsed time: 211.327s, Critical Path: 139.41s
INFO: 297 processes: 350 linux-sandbox, 19 local.
INFO: Build completed successfully, 297 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.4s
//dvaas:dataplane_validation_test                                        PASSED in 0.2s
//dvaas:dvaas_detective_diff_test                                        PASSED in 0.2s
//dvaas:dvaas_detective_test                                             PASSED in 0.2s
//dvaas:port_id_map_test                                                 PASSED in 2.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 4.0s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 2.7s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.5s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.4s
//gutil/gutil:collections_test                                           PASSED in 2.0s
//gutil/gutil:io_test                                                    PASSED in 1.7s
//gutil/gutil:proto_matchers_test                                        PASSED in 1.5s
//gutil/gutil:proto_ordering_test                                        PASSED in 1.5s
//gutil/gutil:proto_test                                                 PASSED in 1.4s
//gutil/gutil:status_matchers_test                                       PASSED in 1.9s
//gutil/gutil:test_artifact_writer_test                                  PASSED in 2.3s
//gutil/gutil:testing_test                                               PASSED in 1.9s
//gutil/gutil:timer_test                                                 PASSED in 5.2s
//gutil/gutil:version_test                                               PASSED in 7.0s
//lib:basic_switch_test                                                  PASSED in 2.6s
//lib:ixia_helper_test                                                   PASSED in 3.6s
//lib:ixia_protocol_helper_test                                          PASSED in 3.1s
//lib:lacp_ixia_helper_test                                              PASSED in 3.9s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 3.5s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.9s
//lib/gnmi:gnmi_helper_test                                              PASSED in 5.4s
//lib/gnoi:gnoi_helper_test                                              PASSED in 1.5s
//lib/p4rt:p4rt_port_test                                                PASSED in 1.4s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 2.7s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.3s
//lib/utils:json_test_utils_test                                         PASSED in 1.6s
//lib/utils:json_utils_test                                              PASSED in 2.3s
//lib/validator:validator_backend_test                                   PASSED in 1.8s
//lib/validator:validator_lib_test                                       PASSED in 28.0s
//p4_fuzzer:constraints_test                                             PASSED in 8.7s
//p4_fuzzer:fuzz_util_test                                               PASSED in 139.2s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 3.1s
//p4_fuzzer:oracle_util_test                                             PASSED in 3.9s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 3.8s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 5.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.3s
//p4_pdpi:built_ins_test                                                 PASSED in 1.5s
//p4_pdpi:entity_keys_test                                               PASSED in 1.7s
//p4_pdpi:ir_properties_test                                             PASSED in 1.7s
//p4_pdpi:ir_to_ir_test                                                  PASSED in 1.7s
//p4_pdpi:ir_tools_test                                                  PASSED in 1.7s
//p4_pdpi:names_test                                                     PASSED in 1.6s
//p4_pdpi:p4_runtime_matchers_test                                       PASSED in 2.5s
//p4_pdpi:p4info_union_test                                              PASSED in 2.0s
//p4_pdpi:reference_annotations_test                                     PASSED in 2.2s
//p4_pdpi:references_test                                                PASSED in 2.2s
//p4_pdpi:sequencing_util_test                                           PASSED in 2.0s
//p4_pdpi:ternary_test                                                   PASSED in 1.4s
//p4_pdpi/netaddr:ipv4_address_and_network_address_test                  PASSED in 1.7s
//p4_pdpi/netaddr:ipv6_address_test                                      PASSED in 1.9s
//p4_pdpi/netaddr:mac_address_test                                       PASSED in 1.8s
//p4_pdpi/packetlib:packetlib_debugging_test                             PASSED in 1.9s
//p4_pdpi/packetlib:packetlib_fuzzer_test                                PASSED in 22.9s
//p4_pdpi/packetlib:packetlib_matchers_test                              PASSED in 1.6s
//p4_pdpi/packetlib:packetlib_test                                       PASSED in 0.4s
//p4_pdpi/packetlib:packetlib_test_runner                                PASSED in 0.5s
//p4_pdpi/packetlib:packetlib_unit_test                                  PASSED in 9.2s
//p4_pdpi/string_encodings:bit_string_test                               PASSED in 1.4s
//p4_pdpi/string_encodings:byte_string_test                              PASSED in 1.7s
//p4_pdpi/string_encodings:decimal_string_test                           PASSED in 0.3s
//p4_pdpi/string_encodings:decimal_string_test_runner                    PASSED in 0.3s
//p4_pdpi/string_encodings:hex_string_test                               PASSED in 0.4s
//p4_pdpi/string_encodings:hex_string_test_runner                        PASSED in 0.4s
//p4_pdpi/string_encodings:readable_byte_string_test                     PASSED in 1.3s
//p4_pdpi/testing:helper_function_test                                   PASSED in 2.2s
//p4_pdpi/testing:info_test                                              PASSED in 0.3s
//p4_pdpi/testing:info_test_runner                                       PASSED in 0.2s
//p4_pdpi/testing:main_pd_test                                           PASSED in 0.1s
//p4_pdpi/testing:mock_p4_runtime_server_test                            PASSED in 1.8s
//p4_pdpi/testing:packet_io_test                                         PASSED in 0.7s
//p4_pdpi/testing:packet_io_test_runner                                  PASSED in 0.4s
//p4_pdpi/testing:references_test                                        PASSED in 0.6s
//p4_pdpi/testing:references_test_runner                                 PASSED in 0.3s
//p4_pdpi/testing:rpc_test                                               PASSED in 0.7s
//p4_pdpi/testing:rpc_test_runner                                        PASSED in 0.5s
//p4_pdpi/testing:sequencing_test                                        PASSED in 0.5s
//p4_pdpi/testing:sequencing_test_runner                                 PASSED in 0.4s
//p4_pdpi/testing:sequencing_util_test                                   PASSED in 0.4s
//p4_pdpi/testing:sequencing_util_test_runner                            PASSED in 1.2s
//p4_pdpi/testing:table_entry_gunit_test                                 PASSED in 1.8s
//p4_pdpi/testing:table_entry_test                                       PASSED in 0.3s
//p4_pdpi/testing:table_entry_test_runner                                PASSED in 0.2s
//p4_pdpi/utils:annotation_parser_test                                   PASSED in 1.4s
//p4_pdpi/utils:ir_test                                                  PASSED in 1.4s
//p4_symbolic:z3_util_test                                               PASSED in 1.9s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.7s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.2s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 1.6s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.2s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 1.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.4s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 1.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 1.4s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.5s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.4s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.3s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.1s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.3s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.3s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.3s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.3s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.2s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.3s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.3s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.3s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.3s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.3s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.2s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.3s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.3s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.2s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.2s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.3s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.2s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.3s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.3s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.9s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 36.7s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 42.0s
//p4_symbolic/sai:sai_test                                               PASSED in 8.7s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.4s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.3s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.8s
//p4_symbolic/symbolic:parser_test                                       PASSED in 3.2s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.3s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.3s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 2.4s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.2s
//p4_symbolic/symbolic:values_test                                       PASSED in 1.9s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.9s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 3.1s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 3.6s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.3s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.3s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.1s
//p4rt_app/event_monitoring:config_db_queue_table_event_test             PASSED in 3.8s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 2.9s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.3s
//p4rt_app/event_monitoring:warm_boot_events_test                        PASSED in 3.7s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 2.9s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.7s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.5s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 4.1s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.1s
//p4rt_app/p4runtime:queue_translator_test                               PASSED in 1.9s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.3s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 3.3s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.4s
//p4rt_app/sonic:hashing_test                                            PASSED in 3.0s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.8s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 2.5s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 2.1s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.4s
//p4rt_app/sonic:state_verification_test                                 PASSED in 3.0s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 2.2s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.5s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.8s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.4s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.2s
//p4rt_app/tests:action_set_test                                         PASSED in 1.7s
//p4rt_app/tests:api_access_test                                         PASSED in 1.4s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.5s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.7s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.6s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 12.0s
//p4rt_app/tests:front_panel_queue_name_and_id_test                      PASSED in 1.7s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.7s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 2.0s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.4s
//p4rt_app/tests:packetio_test                                           PASSED in 4.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.5s
//p4rt_app/tests:resource_limits_test                                    PASSED in 7.0s
//p4rt_app/tests:response_path_test                                      PASSED in 5.7s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.1s
//p4rt_app/tests:utf8_validity_test                                      PASSED in 8.1s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.7s
//p4rt_app/tests:warm_restart_bootup_test                                PASSED in 7.5s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.4s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.4s
//p4rt_app/utils:table_utility_test                                      PASSED in 2.8s
//p4rt_app/utils:warm_restart_utility_test                               PASSED in 0.8s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 1.9s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.3s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.5s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.9s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.2s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 2.5s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 5.1s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.4s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 2.8s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.5s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.1s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 7.9s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 3.9s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 10.9s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.9s
//sai_p4/tools:p4info_tools_test                                         PASSED in 1.8s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.4s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 3.2s
//tests/forwarding:hash_statistics_util_test                             PASSED in 3.0s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 3.0s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.5s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 3.3s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.2s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//tests/sflow:sflow_util_test                                            PASSED in 9.0s
//thinkit:bazel_test_environment_test                                    PASSED in 2.2s
//thinkit:generic_testbed_test                                           PASSED in 3.7s
//thinkit:mock_control_device_test                                       PASSED in 1.7s
//thinkit:mock_generic_testbed_test                                      PASSED in 1.8s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.5s
//thinkit:mock_ssh_client_test                                           PASSED in 0.3s
//thinkit:mock_switch_test                                               PASSED in 2.9s
//thinkit:mock_test_environment_test                                     PASSED in 0.1s
//thinkit:switch_test                                                    PASSED in 2.5s
//tests/lib:packet_generator_test                                        PASSED in 68.1s
  Stats over 4 runs: max = 68.1s, min = 65.3s, avg = 66.5s, dev = 1.0s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 3.0s
  Stats over 5 runs: max = 3.0s, min = 2.3s, avg = 2.7s, dev = 0.3s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 46.2s
  Stats over 50 runs: max = 46.2s, min = 1.9s, avg = 4.6s, dev = 8.6s

Executed 240 out of 240 tests: 240 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.



