### PR TITLE
[P4RT] Remove redundant code and wrap SavePipelineConfig in commit check.

### DIFF
--- a/p4rt_app/p4runtime/p4runtime_impl.cc
+++ b/p4rt_app/p4runtime/p4runtime_impl.cc
@@ -1933,35 +1933,17 @@ grpc::Status P4RuntimeImpl::ReconcileAndCommitPipelineConfig(
     }
   }
 
-  // Configure the lower layers.
-  // Apply ir_p4info to DB if we are committing to DB.
-  // Apply a config if we don't currently have one.
-  absl::Status config_result = ConfigureAppDbTables(config_info->ir_p4info);
-  if (!config_result.ok()) {
-    return EnterCriticalState(
-        absl::StrCat("Failed to apply ForwardingPipelineConfig: ",
-                     config_result.ToString()));
-  }
-
-    // Store resource utilization limits for any ActionProfiles.
-  for (const auto &[action_profile_name, action_profile_def] :
-       config_info->ir_p4info.action_profiles_by_name()) {
-    capacity_by_action_profile_name_[action_profile_name] =
-        GetActionProfileResourceCapacity(action_profile_def);
-    LOG(INFO) << "Adding action profile limits for '" << action_profile_name
-              << "': max_weights_for_all_groups="
-              << action_profile_def.action_profile().size();
-  }
-
-    // Update P4RuntimeImpl's state only if we succeed.
+  // Update P4RuntimeImpl's state only if we succeed.
   p4_constraint_info_ = std::move(config_info->constraints);
   ir_p4info_ = std::move(config_info->ir_p4info);
   forwarding_pipeline_config_ = request.config();
 
   // Save the ForwardingPipelineConfig if we are committing.
-  LOG(INFO)
-      << "ForwardingPipelineConfig was successfully applied. Saving to disk.";
-  return SavePipelineConfig(*forwarding_pipeline_config_);
+  if (commit_to_hardware) {
+    LOG(INFO)
+        << "ForwardingPipelineConfig was successfully applied. Saving to disk.";
+    return SavePipelineConfig(*forwarding_pipeline_config_);
+  }
   return grpc::Status::OK;
 }
 


### PR DESCRIPTION
### Build Results:
divyagayathris@6a0a791d9bed:/sonic/src/sonic-p4rt/sonic-pins$ bazel build $BAZEL_BUILD_OPTS ...
INFO: Analyzed 773 targets (1 packages loaded, 396 targets configured).
INFO: Found 773 targets...
INFO: From Compiling p4rt_app/p4runtime/p4runtime_impl.cc:

INFO: Elapsed time: 49.795s, Critical Path: 48.52s
INFO: 39 processes: 3 internal, 36 linux-sandbox.
INFO: Build completed successfully, 39 total actions

### Test Results:
divyagayathris@6a0a791d9bed:/sonic/src/sonic-p4rt/sonic-pins$ bazel test $BAZEL_BUILD_OPTS --cache_test_results=no ...
INFO: Analyzed 773 targets (0 packages loaded, 391 targets configured).
INFO: Found 536 targets and 237 test targets...
INFO: Elapsed time: 142.302s, Critical Path: 66.87s
INFO: 303 processes: 356 linux-sandbox, 19 local.
INFO: Build completed successfully, 303 total actions
//dvaas:dataplane_validation_diff_test                                   PASSED in 0.2s
//dvaas:dataplane_validation_test                                        PASSED in 0.3s
//dvaas:failure_post_processing_test                                     PASSED in 1.7s
//dvaas:labeler_test                                                     PASSED in 1.9s
//dvaas:packet_trace_test                                                PASSED in 2.1s
//dvaas:port_id_map_test                                                 PASSED in 3.1s
//dvaas:test_insights_diff_test                                          PASSED in 0.2s
//dvaas:test_insights_test                                               PASSED in 0.1s
//dvaas:test_run_validation_golden_test                                  PASSED in 0.2s
//dvaas:test_run_validation_test                                         PASSED in 3.1s
//dvaas:test_run_validation_test_runner                                  PASSED in 0.1s
//dvaas:test_vector_stats_diff_test                                      PASSED in 0.2s
//dvaas:test_vector_stats_test                                           PASSED in 0.1s
//dvaas:test_vector_test                                                 PASSED in 2.6s
//dvaas:user_provided_packet_test_vector_diff_test                       PASSED in 0.2s
//dvaas:user_provided_packet_test_vector_test                            PASSED in 0.2s
//dvaas:validation_result_test                                           PASSED in 3.0s
//lib:basic_switch_test                                                  PASSED in 2.6s
//lib:ixia_helper_test                                                   PASSED in 2.8s
//lib:ixia_protocol_helper_test                                          PASSED in 3.0s
//lib:lacp_ixia_helper_test                                              PASSED in 2.8s
//lib:otg_helper_test                                                    PASSED in 2.4s
//lib/basic_traffic:basic_p4rt_util_test                                 PASSED in 2.8s
//lib/basic_traffic:basic_traffic_test                                   PASSED in 17.3s
//lib/gnmi:gnmi_helper_test                                              PASSED in 5.5s
//lib/gnoi:gnoi_helper_test                                              PASSED in 2.1s
//lib/p4rt:p4rt_port_test                                                PASSED in 2.2s
//lib/p4rt:p4rt_programming_context_test                                 PASSED in 3.0s
//lib/ssh:mock_linux_ssh_helper_test                                     PASSED in 0.1s
//lib/utils:generic_testbed_utils_test                                   PASSED in 3.2s
//lib/utils:json_test_utils_test                                         PASSED in 2.2s
//lib/utils:json_utils_test                                              PASSED in 1.8s
//lib/utils:merging_status_bundle_test                                   PASSED in 2.1s
//lib/validator:config_validator_test                                    PASSED in 3.1s
//lib/validator:validator_backend_test                                   PASSED in 2.1s
//lib/validator:validator_lib_test                                       PASSED in 27.7s
//p4_fuzzer:constraints_test                                             PASSED in 11.4s
//p4_fuzzer:fuzzer_config_test                                           PASSED in 2.5s
//p4_fuzzer:oracle_util_test                                             PASSED in 5.9s
//p4_fuzzer:switch_state_assert_entry_equality_test                      PASSED in 4.1s
//p4_fuzzer:switch_state_assert_entry_equality_test_runner               PASSED in 4.1s
//p4_fuzzer:switch_state_test                                            PASSED in 2.7s
//p4_infra/netaddr:ipv4_address_and_network_address_test                 PASSED in 2.1s
//p4_infra/netaddr:ipv6_address_test                                     PASSED in 2.0s
//p4_infra/netaddr:mac_address_test                                      PASSED in 2.1s
//p4_infra/p4_pdpi:annotation_parser_test                                PASSED in 2.1s
//p4_infra/p4_pdpi:built_ins_test                                        PASSED in 2.3s
//p4_infra/p4_pdpi:entity_keys_test                                      PASSED in 2.4s
//p4_infra/p4_pdpi:helper_function_test                                  PASSED in 2.6s
//p4_infra/p4_pdpi:ir_properties_test                                    PASSED in 1.9s
//p4_infra/p4_pdpi:ir_to_ir_test                                         PASSED in 2.4s
//p4_infra/p4_pdpi:ir_tools_test                                         PASSED in 2.4s
//p4_infra/p4_pdpi:ir_utils_test                                         PASSED in 2.4s
//p4_infra/p4_pdpi:main_pd_diff_test                                     PASSED in 0.1s
//p4_infra/p4_pdpi:names_test                                            PASSED in 2.2s
//p4_infra/p4_pdpi:p4info_diff_test                                      PASSED in 0.3s
//p4_infra/p4_pdpi:p4info_test_runner                                    PASSED in 0.3s
//p4_infra/p4_pdpi:p4info_union_test                                     PASSED in 2.3s
//p4_infra/p4_pdpi:packet_io_diff_test                                   PASSED in 0.2s
//p4_infra/p4_pdpi:packet_io_test_runner                                 PASSED in 0.2s
//p4_infra/p4_pdpi:reference_annotations_test                            PASSED in 2.4s
//p4_infra/p4_pdpi:references_diff_test                                  PASSED in 0.5s
//p4_infra/p4_pdpi:references_test                                       PASSED in 2.2s
//p4_infra/p4_pdpi:references_test_runner                                PASSED in 0.3s
//p4_infra/p4_pdpi:rpc_diff_test                                         PASSED in 0.3s
//p4_infra/p4_pdpi:rpc_test_runner                                       PASSED in 0.3s
//p4_infra/p4_pdpi:sequencing_diff_test                                  PASSED in 0.4s
//p4_infra/p4_pdpi:sequencing_test_runner                                PASSED in 0.3s
//p4_infra/p4_pdpi:sequencing_util_diff_test                             PASSED in 0.4s
//p4_infra/p4_pdpi:sequencing_util_test                                  PASSED in 1.6s
//p4_infra/p4_pdpi:sequencing_util_test_runner                           PASSED in 0.3s
//p4_infra/p4_pdpi:table_entry_diff_test                                 PASSED in 0.5s
//p4_infra/p4_pdpi:table_entry_gunit_test                                PASSED in 1.9s
//p4_infra/p4_pdpi:table_entry_test_runner                               PASSED in 0.3s
//p4_infra/p4_pdpi:ternary_test                                          PASSED in 1.8s
//p4_infra/p4_runtime:p4_runtime_matchers_test                           PASSED in 1.5s
//p4_infra/packetlib:packetlib_debugging_test                            PASSED in 1.5s
//p4_infra/packetlib:packetlib_fuzzer_test                               PASSED in 21.9s
//p4_infra/packetlib:packetlib_matchers_test                             PASSED in 1.6s
//p4_infra/packetlib:packetlib_test                                      PASSED in 0.5s
//p4_infra/packetlib:packetlib_test_runner                               PASSED in 0.3s
//p4_infra/packetlib:packetlib_unit_test                                 PASSED in 23.7s
//p4_infra/string_encodings:bit_string_test                              PASSED in 1.7s
//p4_infra/string_encodings:byte_string_test                             PASSED in 1.6s
//p4_infra/string_encodings:decimal_string_test                          PASSED in 0.1s
//p4_infra/string_encodings:decimal_string_test_runner                   PASSED in 0.2s
//p4_infra/string_encodings:hex_string_test                              PASSED in 0.2s
//p4_infra/string_encodings:hex_string_test_runner                       PASSED in 0.1s
//p4_infra/string_encodings:readable_byte_string_test                    PASSED in 1.6s
//p4_symbolic:z3_util_test                                               PASSED in 1.6s
//p4_symbolic/bmv2:ipv4_routing_exact_test                               PASSED in 0.1s
//p4_symbolic/bmv2:ipv4_routing_subset_test                              PASSED in 0.3s
//p4_symbolic/bmv2:port_hardcoded_exact_test                             PASSED in 0.1s
//p4_symbolic/bmv2:port_hardcoded_subset_test                            PASSED in 0.2s
//p4_symbolic/bmv2:port_table_exact_test                                 PASSED in 0.1s
//p4_symbolic/bmv2:port_table_subset_test                                PASSED in 0.3s
//p4_symbolic/bmv2:reflector_exact_test                                  PASSED in 0.1s
//p4_symbolic/bmv2:reflector_subset_test                                 PASSED in 0.3s
//p4_symbolic/bmv2:set_invalid_exact_test                                PASSED in 0.1s
//p4_symbolic/bmv2:set_invalid_subset_test                               PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_1_subset_test                               PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_exact_test                                PASSED in 0.2s
//p4_symbolic/bmv2:table_hit_2_subset_test                               PASSED in 0.3s
//p4_symbolic/ir:cfg_test                                                PASSED in 2.2s
//p4_symbolic/ir:complex_conditional_test                                PASSED in 0.2s
//p4_symbolic/ir:conditional_sequence_test                               PASSED in 0.1s
//p4_symbolic/ir:conditional_test                                        PASSED in 0.1s
//p4_symbolic/ir:default_transition_test                                 PASSED in 0.1s
//p4_symbolic/ir:extract_parser_operation_test                           PASSED in 0.1s
//p4_symbolic/ir:fall_through_transition_test                            PASSED in 0.1s
//p4_symbolic/ir:hex_string_transition_test                              PASSED in 0.1s
//p4_symbolic/ir:ipv4_routing_test                                       PASSED in 0.2s
//p4_symbolic/ir:partial_icmp_test                                       PASSED in 0.1s
//p4_symbolic/ir:port_hardcoded_test                                     PASSED in 0.1s
//p4_symbolic/ir:port_table_test                                         PASSED in 0.1s
//p4_symbolic/ir:primitive_parser_operation_test                         PASSED in 0.1s
//p4_symbolic/ir:reflector_test                                          PASSED in 0.2s
//p4_symbolic/ir:sai_parser_test                                         PASSED in 0.1s
//p4_symbolic/ir:set_invalid_test                                        PASSED in 0.2s
//p4_symbolic/ir:set_parser_operation_test                               PASSED in 0.1s
//p4_symbolic/ir:string_optional_test                                    PASSED in 0.1s
//p4_symbolic/ir:table_hit_1_test                                        PASSED in 0.2s
//p4_symbolic/ir:table_hit_2_test                                        PASSED in 0.1s
//p4_symbolic/packet_synthesizer:packet_synthesis_criteria_test          PASSED in 1.6s
//p4_symbolic/sai:criteria_generator_test                                PASSED in 37.4s
//p4_symbolic/sai:packet_synthesizer_test                                PASSED in 41.3s
//p4_symbolic/sai:sai_test                                               PASSED in 8.4s
//p4_symbolic/symbolic:conditional_sequence_test_packets                 PASSED in 0.2s
//p4_symbolic/symbolic:condtional_test_packets                           PASSED in 0.3s
//p4_symbolic/symbolic:deparser_test                                     PASSED in 3.7s
//p4_symbolic/symbolic:parser_test                                       PASSED in 1.9s
//p4_symbolic/symbolic:port_hardcoded_test_packets                       PASSED in 0.1s
//p4_symbolic/symbolic:port_table_test_packets                           PASSED in 0.2s
//p4_symbolic/symbolic:symbolic_table_entry_test                         PASSED in 3.0s
//p4_symbolic/symbolic:util_test                                         PASSED in 2.2s
//p4_symbolic/symbolic:values_test                                       PASSED in 2.1s
//p4_symbolic/tests:sai_p4_integration_test                              PASSED in 20.8s
//p4_symbolic/tests:symbolic_table_entries_test                          PASSED in 2.8s
//p4rt_app/event_monitoring:app_state_db_port_table_event_test           PASSED in 2.9s
//p4rt_app/event_monitoring:app_state_db_send_to_ingress_port_table_event_test PASSED in 3.4s
//p4rt_app/event_monitoring:config_db_node_cfg_table_event_test          PASSED in 3.2s
//p4rt_app/event_monitoring:config_db_port_table_event_test              PASSED in 3.4s
//p4rt_app/event_monitoring:config_db_queue_table_event_test             PASSED in 3.4s
//p4rt_app/event_monitoring:debug_data_dump_events_test                  PASSED in 3.6s
//p4rt_app/event_monitoring:state_verification_events_test               PASSED in 3.1s
//p4rt_app/event_monitoring:warm_boot_events_test                        PASSED in 3.0s
//p4rt_app/p4runtime:ir_translation_test                                 PASSED in 3.3s
//p4rt_app/p4runtime:p4info_reconcile_test                               PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_schema_test                     PASSED in 2.3s
//p4rt_app/p4runtime:p4info_verification_test                            PASSED in 3.4s
//p4rt_app/p4runtime:packetio_helpers_test                               PASSED in 3.0s
//p4rt_app/p4runtime:queue_translator_test                               PASSED in 1.6s
//p4rt_app/p4runtime:resource_utilization_test                           PASSED in 2.7s
//p4rt_app/sonic:app_db_acl_def_table_manager_test                       PASSED in 2.4s
//p4rt_app/sonic:app_db_manager_test                                     PASSED in 2.7s
//p4rt_app/sonic:app_db_to_pdpi_ir_translator_test                       PASSED in 2.7s
//p4rt_app/sonic:hashing_test                                            PASSED in 2.3s
//p4rt_app/sonic:packet_replication_entry_translation_test               PASSED in 2.3s
//p4rt_app/sonic:packetio_impl_test                                      PASSED in 1.7s
//p4rt_app/sonic:packetio_port_test                                      PASSED in 1.8s
//p4rt_app/sonic:response_handler_test                                   PASSED in 2.0s
//p4rt_app/sonic:state_verification_test                                 PASSED in 2.5s
//p4rt_app/sonic:swss_utils_test                                         PASSED in 2.1s
//p4rt_app/sonic:vlan_entry_translation_test                             PASSED in 2.3s
//p4rt_app/sonic:vrf_entry_translation_test                              PASSED in 2.4s
//p4rt_app/sonic/adapters:fake_sonic_db_table_test                       PASSED in 1.5s
//p4rt_app/sonic/adapters:fake_warm_boot_state_adapter_test              PASSED in 0.2s
//p4rt_app/tests:acl_table_test                                          PASSED in 2.3s
//p4rt_app/tests:action_set_test                                         PASSED in 1.7s
//p4rt_app/tests:api_access_test                                         PASSED in 1.4s
//p4rt_app/tests:arbitration_test                                        PASSED in 1.6s
//p4rt_app/tests:cpu_queue_name_and_id_test                              PASSED in 2.7s
//p4rt_app/tests:debug_data_dump_test                                    PASSED in 1.9s
//p4rt_app/tests:fixed_l3_tables_test                                    PASSED in 4.7s
//p4rt_app/tests:forwarding_pipeline_config_test                         PASSED in 21.7s
//p4rt_app/tests:front_panel_queue_name_and_id_test                      PASSED in 1.8s
//p4rt_app/tests:grpc_behavior_test                                      PASSED in 5.8s
//p4rt_app/tests:p4_constraints_test                                     PASSED in 1.3s
//p4rt_app/tests:p4_constraints_test_runner                              PASSED in 0.5s
//p4rt_app/tests:p4_programs_test                                        PASSED in 2.5s
//p4rt_app/tests:packet_replication_table_test                           PASSED in 3.4s
//p4rt_app/tests:packetio_test                                           PASSED in 4.7s
//p4rt_app/tests:port_name_and_id_test                                   PASSED in 4.4s
//p4rt_app/tests:resource_limits_test                                    PASSED in 7.7s
//p4rt_app/tests:response_path_test                                      PASSED in 5.6s
//p4rt_app/tests:role_test                                               PASSED in 1.7s
//p4rt_app/tests:state_verification_test                                 PASSED in 3.1s
//p4rt_app/tests:utf8_validity_test                                      PASSED in 7.0s
//p4rt_app/tests:vrf_table_test                                          PASSED in 2.7s
//p4rt_app/tests:warm_restart_bootup_test                                PASSED in 6.6s
//p4rt_app/tests/lib:app_db_entry_builder_test                           PASSED in 0.2s
//p4rt_app/utils:event_data_tracker_test                                 PASSED in 0.1s
//p4rt_app/utils:table_utility_test                                      PASSED in 12.4s
//p4rt_app/utils:warm_restart_utility_test                               PASSED in 0.3s
//sai_p4:capabilities_test                                               PASSED in 2.5s
//sai_p4/instantiations/google:clos_stage_test                           PASSED in 2.0s
//sai_p4/instantiations/google:fabric_border_router_p4info_up_to_date_test PASSED in 0.1s
//sai_p4/instantiations/google:middleblock_p4info_up_to_date_test        PASSED in 0.2s
//sai_p4/instantiations/google:preprocessed_sai_programs_test            PASSED in 0.3s
//sai_p4/instantiations/google:sai_nonstandard_platforms_build_test      PASSED in 0.1s
//sai_p4/instantiations/google:sai_nonstandard_platforms_cc_test         PASSED in 2.6s
//sai_p4/instantiations/google:sai_p4info_fetcher_test                   PASSED in 2.3s
//sai_p4/instantiations/google:sai_p4info_test                           PASSED in 3.8s
//sai_p4/instantiations/google:sai_pd_proto_test                         PASSED in 0.2s
//sai_p4/instantiations/google:sai_pd_util_test                          PASSED in 2.4s
//sai_p4/instantiations/google:tor_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google:union_p4info_up_to_date_test              PASSED in 0.4s
//sai_p4/instantiations/google:wbb_p4info_up_to_date_test                PASSED in 0.2s
//sai_p4/instantiations/google/test_tools:table_entry_generator_helper_test PASSED in 17.4s
//sai_p4/instantiations/google/test_tools:test_entries_test              PASSED in 4.4s
//sai_p4/instantiations/google/tests:p4_fuzzer_integration_test          PASSED in 9.7s
//sai_p4/tools:auxiliary_entries_for_v1model_targets_test                PASSED in 2.9s
//sai_p4/tools:p4info_tools_test                                         PASSED in 2.0s
//sai_p4/tools:packetio_tools_test                                       PASSED in 2.6s
//tests:thinkit_gnmi_interface_util_tests                                PASSED in 4.0s
//tests/forwarding:hash_statistics_util_test                             PASSED in 3.3s
//tests/integration/system/nsf:compare_p4flows_test                      PASSED in 2.4s
//tests/lib:common_ir_table_entries_test                                 PASSED in 2.4s
//tests/lib:p4rt_fixed_table_programming_helper_test                     PASSED in 3.2s
//tests/lib:switch_test_setup_helpers_golden_test                        PASSED in 0.3s
//tests/lib:switch_test_setup_helpers_golden_test_runner                 PASSED in 0.3s
//tests/qos:gnmi_parsers_test                                            PASSED in 0.2s
//tests/qos:gnmi_parsers_test_runner                                     PASSED in 0.1s
//thinkit:bazel_test_environment_test                                    PASSED in 2.5s
//thinkit:generic_testbed_test                                           PASSED in 3.4s
//thinkit:mock_control_device_test                                       PASSED in 2.2s
//thinkit:mock_generic_testbed_test                                      PASSED in 3.5s
//thinkit:mock_mirror_testbed_test                                       PASSED in 2.6s
//thinkit:mock_ssh_client_test                                           PASSED in 0.2s
//thinkit:mock_switch_test                                               PASSED in 1.8s
//thinkit:mock_test_environment_test                                     PASSED in 0.2s
//thinkit:switch_test                                                    PASSED in 2.4s
//tests/lib:packet_generator_test                                        PASSED in 66.6s
  Stats over 4 runs: max = 66.6s, min = 63.5s, avg = 64.6s, dev = 1.2s
//sai_p4/instantiations/google/tests:p4_constraints_integration_test     PASSED in 2.8s
  Stats over 5 runs: max = 2.8s, min = 2.2s, avg = 2.5s, dev = 0.2s
//p4_fuzzer:fuzz_util_test                                               PASSED in 39.1s
  Stats over 10 runs: max = 39.1s, min = 2.6s, avg = 16.5s, dev = 13.8s
//sai_p4/instantiations/google/test_tools:table_entry_generator_test     PASSED in 45.0s
  Stats over 50 runs: max = 45.0s, min = 1.4s, avg = 4.9s, dev = 10.2s

Executed 237 out of 237 tests: 237 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.